### PR TITLE
ethernet: add ssh options to avoid conflicting key

### DIFF
--- a/lib/oeqa/runtime/ethernet/files/ipv6_ssh.exp
+++ b/lib/oeqa/runtime/ethernet/files/ipv6_ssh.exp
@@ -5,7 +5,7 @@ set ip6      [lindex $argv 0]
 set password [lindex $argv 1]
 set eth      [lindex $argv 2]
 
-spawn ssh root@$ip6%$eth ls /
+spawn ssh root@$ip6%$eth -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR ls /
  expect {
  "yes/no"
    {


### PR DESCRIPTION
When device image is rebuilt, the original ssh key in host will
have conflict. Add ssh options to avoid this.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>