### PR TITLE
security.manifest: add IMA tests

### DIFF
--- a/conf/test/security.manifest
+++ b/conf/test/security.manifest
@@ -4,3 +4,4 @@ oeqa.runtime.security.appmemoryprotection
 oeqa.runtime.security.ca_certificate
 oeqa.runtime.security.dac_config
 oeqa.runtime.security.firewall_rules
+oeqa.runtime.ima


### PR DESCRIPTION
Adding oeqa.runtime.ima to security.manifest
IMA tests can be found in github.com/01org/meta-intel-iot-security,
path meta-integrity/lib/oeqa/runtime/ima.py