### PR TITLE
802.15.4: add 1 802.15.4 case for sanity check

### DIFF
--- a/conf/test/zigbee.manifest
+++ b/conf/test/zigbee.manifest
@@ -1,0 +1,2 @@
+#this is only for Galileo and MinnowMax
+oeqa.runtime.zigbee.comm_zigbee_basic

--- a/lib/oeqa/runtime/zigbee/comm_zigbee_basic.py
+++ b/lib/oeqa/runtime/zigbee/comm_zigbee_basic.py
@@ -1,0 +1,48 @@
+"""
+@file comm_zigbee_basic.py
+"""
+
+##
+# @addtogroup zigbee
+# @brief This is component
+# @{
+# @addtogroup comm_zigbee
+# @brief This is comm_zigbee module
+# @{
+##
+
+import time
+import os
+import string
+import zigbee
+from oeqa.oetest import oeRuntimeTest
+from oeqa.utils.helper import shell_cmd_timeout
+from oeqa.utils.decorators import tag
+
+@tag(TestType="FVT")
+class ZigBeeBasic(oeRuntimeTest):
+    """
+    @class ZigBeeBasic
+    """
+    def setUp(self):
+        ''' initialize zigbee class 
+        @fn setUp
+        @param self
+        @return
+        '''
+        self.zigbee = zigbee.ZigBeeFunction(self.target)
+
+    @tag(FeatureID="IOTOS-1220")
+    def test_insert_atmel_module(self):
+        '''Insert atmel module to enable 802.15.4
+        @fn test_insert_atmel_module
+        @param self
+        @return
+        '''
+        self.zigbee.insert_atmel_mode()
+
+##
+# @}
+# @}
+##
+

--- a/lib/oeqa/runtime/zigbee/zigbee.py
+++ b/lib/oeqa/runtime/zigbee/zigbee.py
@@ -1,0 +1,81 @@
+"""
+@file zigbee.py
+"""
+
+##
+# @addtogroup zigbee
+# @brief This is zigbee component
+# @{
+# @addtogroup comm_zigbee
+# @brief This is comm_zigbee module
+# @{
+##
+
+import time
+import os
+import string
+from oeqa.utils.helper import shell_cmd_timeout
+
+class ZigBeeFunction(object):
+    """
+    @class ZigBeeFunction
+    """
+    platform = ""
+    atmel_mod_name = ""
+    cc2520_mod_name = ""
+    log = ""
+    def __init__(self, target):
+        self.target = target
+        self.init_platform()
+
+    def target_collect_info(self, cmd):
+        """
+        @fn target_collect_info
+        @param self
+        @param  cmd
+        @return
+        """
+        (status, output) = self.target.run(cmd)
+        self.log = self.log + "\n\n[Debug] Command output --- %s: \n" % cmd
+        self.log = self.log + output
+
+    def init_platform(self):
+        '''based on uname -a, check which platform and its module name'''
+        """
+        @fn 
+        @param self
+        @return
+        """
+        (status, output) = self.target.run('uname -a')
+        if "intel-quark" in output:
+            self.platform="Galileo"
+            self.atmel_mod_name="spi-quark-board"
+        elif "intel-corei7-64" in output:
+            # Here assume case is not played on GB-BXBT, for uname arch are same
+            self.platform="MinnowMax"
+            self.atmel_mod_name="spi-minnow-board"
+            self.cc2520_mod_name="spi-minnow-cc2520"
+        else:
+            assert False, "The platform does not support 6lowpan. check: %s" % output
+
+    def insert_atmel_mode(self):
+        ''' Insert atmel modules 
+        @fn insert_atmel_mode
+        @param self
+        @return
+        '''
+        (status, output) = self.target.run('dmesg -c')
+        (status, output) = self.target.run('modprobe %s' % self.atmel_mod_name)
+        assert status == 0, "Error messages: %s" % output 
+        # Check dmesg log, to see if the 802.15.4 is registered
+        (status, output) = self.target.run('dmesg')
+        if "802.15.4 chip registered" in output:
+            pass
+        else:
+            assert False, "Not initialize 802.15.4 module. see dmesg log:\n%s" % output 
+
+##
+# @}
+# @}
+##
+


### PR DESCRIPTION
Add one 802.15.4 case to check inserting 80.15.4 module.
This case is only runable on Galileo and MinnowMax platform.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>