### PR TITLE
zigbee: add 1 cc2520 case and 1 zigbee ping case

### DIFF
--- a/conf/test/galileo.fullauto.manifest
+++ b/conf/test/galileo.fullauto.manifest
@@ -26,3 +26,5 @@ oeqa.runtime.ima
 oeqa.runtime.security.openssl
 oeqa.runtime.wifi.comm_wifi_connect_7260
 oeqa.runtime.sanity.reboot
+oeqa.runtime.zigbee.comm_zigbee_basic
+oeqa.runtime.zigbee.comm_zigbee_mnode

--- a/conf/test/minnowmax.fullauto.manifest
+++ b/conf/test/minnowmax.fullauto.manifest
@@ -22,3 +22,6 @@ oeqa.runtime.security.firewall_rules
 oeqa.runtime.ima 
 oeqa.runtime.security.openssl
 oeqa.runtime.sanity.reboot
+oeqa.runtime.zigbee.comm_zigbee_basic
+oeqa.runtime.zigbee.comm_zigbee_cc2520
+oeqa.runtime.zigbee.comm_zigbee_mnode

--- a/conf/test/zigbee.manifest
+++ b/conf/test/zigbee.manifest
@@ -1,2 +1,3 @@
 #this is only for Galileo and MinnowMax
 oeqa.runtime.zigbee.comm_zigbee_basic
+oeqa.runtime.zigbee.comm_zigbee_mnode

--- a/lib/oeqa/runtime/zigbee/comm_zigbee_cc2520.py
+++ b/lib/oeqa/runtime/zigbee/comm_zigbee_cc2520.py
@@ -1,0 +1,48 @@
+"""
+@file comm_zigbee_cc2520.py
+"""
+
+##
+# @addtogroup zigbee
+# @brief This is component
+# @{
+# @addtogroup comm_zigbee
+# @brief This is comm_zigbee module
+# @{
+##
+
+import time
+import os
+import string
+import zigbee
+from oeqa.oetest import oeRuntimeTest
+from oeqa.utils.helper import shell_cmd_timeout
+from oeqa.utils.decorators import tag
+
+@tag(TestType="FVT")
+class ZigBeeCC2520(oeRuntimeTest):
+    """
+    @class ZigBeeCC2520
+    """
+    def setUp(self):
+        ''' initialize zigbee class 
+        @fn setUp
+        @param self
+        @return
+        '''
+        self.zigbee = zigbee.ZigBeeFunction(self.target)
+
+    @tag(FeatureID="IOTOS-763")
+    def test_insert_cc2520_module(self):
+        '''Insert cc2520 module
+        @fn test_insert_cc2520_module
+        @param self
+        @return
+        '''
+        self.zigbee.insert_cc2520_mode()
+
+##
+# @}
+# @}
+##
+

--- a/lib/oeqa/runtime/zigbee/comm_zigbee_mnode.py
+++ b/lib/oeqa/runtime/zigbee/comm_zigbee_mnode.py
@@ -1,0 +1,51 @@
+"""
+@file comm_zigbee_mnode.py
+"""
+
+##
+# @addtogroup zigbee
+# @brief This is component
+# @{
+# @addtogroup comm_zigbee
+# @brief This is comm_zigbee module
+# @{
+##
+
+import time
+import os
+import string
+import zigbee
+from oeqa.oetest import oeRuntimeTest
+from oeqa.utils.helper import shell_cmd_timeout
+from oeqa.utils.helper import run_as
+from oeqa.utils.decorators import tag
+
+@tag(TestType="FVT")
+class ZigBeeMNode(oeRuntimeTest):
+    """
+    @class ZigBeeMNode
+    """
+    def setUp(self):
+        ''' initialize zigbee class 
+        @fn setUp
+        @param self
+        @return
+        '''
+        self.zigbee = zigbee.ZigBeeFunction(self.targets)
+
+    @tag(FeatureID="IOTOS-1220")
+    def test_zigbee_atmel_ping6(self):
+        '''Setup two devices with atmel, and ping each other
+        @fn test_zigbee_atmel_ping6
+        @param self
+        @return
+        '''
+        self.zigbee.atmel_enable_lowpan0(0)
+        self.zigbee.atmel_enable_lowpan0(1)
+        self.zigbee.lowpan0_ping6_check(0, 1)     
+
+##
+# @}
+# @}
+##
+

--- a/lib/oeqa/runtime/zigbee/zigbee.py
+++ b/lib/oeqa/runtime/zigbee/zigbee.py
@@ -15,6 +15,7 @@ import time
 import os
 import string
 from oeqa.utils.helper import shell_cmd_timeout
+from oeqa.utils.helper import run_as
 
 class ZigBeeFunction(object):
     """
@@ -24,8 +25,9 @@ class ZigBeeFunction(object):
     atmel_mod_name = ""
     cc2520_mod_name = ""
     log = ""
-    def __init__(self, target):
-        self.target = target
+    def __init__(self, targets):
+        self.targets = targets
+        self.target = targets[0]
         self.init_platform()
 
     def target_collect_info(self, cmd):
@@ -73,6 +75,79 @@ class ZigBeeFunction(object):
             pass
         else:
             assert False, "Not initialize 802.15.4 module. see dmesg log:\n%s" % output 
+
+    def insert_cc2520_mode(self):
+        ''' Insert cc2520 modules 
+        @fn insert_cc2520_mode
+        @param self
+        @return
+        '''
+        (status, output) = self.target.run('modprobe %s' % self.cc2520_mod_name)
+        assert status == 0, "Error messages: %s" % output 
+        # Check dmesg log, to see if the 802.15.4 is registered
+        (status, output) = self.target.run('lsmod')
+        if self.cc2520_mod_name in output:
+            pass
+        else:
+            assert False, "Not initialize cc2520 module. see lsmod:\n%s" % output
+
+    def atmel_enable_lowpan0(self, target_number):
+        ''' enable atmel chipset on target 
+        @fn atmel_enable_lowpan0
+        @param self
+        @param target_number: 0 stands for main_target, 1 stands for second target
+        @return
+        '''
+        # get device ip for debug
+        my_ip=self.targets[target_number].ip
+      
+        # insert module
+        cmd='modprobe %s' % self.atmel_mod_name
+        (status, output) = run_as('root', cmd, target=self.targets[target_number])
+        time.sleep(1)
+        assert status == 0, "[%s] Insert atmel module fails: %s" % (my_ip, output)
+        # set wpan0
+        ip_set="ip link set wpan0 address a0:0:0:0:0:0:0:%d" % (target_number+1)
+        (status, output) = run_as('root', ip_set, target=self.targets[target_number]) 
+        time.sleep(1)
+        # set channel as 5
+        wpan_set="iz set wpan0 777 800%d 5" % (target_number+1)
+        (status, output) = run_as('root', wpan_set, target=self.targets[target_number]) 
+        time.sleep(1)
+        # bring up wpan0
+        (status, output) = run_as('root', 'ifconfig wpan0 up', target=self.targets[target_number]) 
+        time.sleep(1)
+        assert status == 0, "[%s] Bring up wpan0 fails: %s" % (my_ip, output)
+        # add lowpan0 
+        (status, output) = run_as('root', 'ip link add link wpan0 name lowpan0 type lowpan', target=self.targets[target_number]) 
+        time.sleep(1)
+        # bring up lowpan0
+        (status, output) = run_as('root', 'ifconfig lowpan0 up', target=self.targets[target_number]) 
+        time.sleep(1)
+        assert status == 0, "[%s] Bring up lowpan0 fails: %s" % (my_ip, output)
+
+    def get_lowpan0_ip(self, target_number):  
+        ''' Get lowpan0 (ipv6) address 
+        @fn get_lowpan0_ip
+        @param self
+        @param target_number: 0 stands for main_target, 1 stands for second target
+        @return
+        '''
+        cmd="ifconfig lowpan0 | grep 'inet6 addr:'"
+        (status, output) = run_as('root', cmd, target=self.targets[target_number])
+        return output.split('%')[0].split()[2]    
+
+    def lowpan0_ping6_check(self, main, second):
+        ''' On main target, run ping6 to ping second's ipv6 address 
+        @fn ping6_check
+        @param self
+        @param main: main target number
+        @param second: second target number 
+        @return
+        '''
+        cmd='ping6 -I lowpan0 -c 1 %s' % self.get_lowpan0_ip(second)
+        (status, output) = run_as('root', cmd, target=self.targets[main])
+        assert status == 0, "Ping second target lowpan0 ipv6 address fail: %s" % output
 
 ##
 # @}


### PR DESCRIPTION
Add two cases for zigbee check:
One is for cc2520 module insert (only for MinnowMax)
The other is for atmel zigbee ping between 2 IoT devices.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>