### PR TITLE
meta-iotqa: add qa test app for appfw

### DIFF
--- a/recipes-core/packagegroups/packagegroup-qa-tests.bb
+++ b/recipes-core/packagegroups/packagegroup-qa-tests.bb
@@ -8,4 +8,5 @@ RDEPENDS_${PN} = " \
     example-app-node \
     example-app-python \
     bad-groups-app \
+    appfw-test-app \
 "

--- a/recipes-test/appfw-test-app/appfw-test-app.bb
+++ b/recipes-test/appfw-test-app/appfw-test-app.bb
@@ -1,0 +1,28 @@
+DESCRIPTION = "AppFW Test App"
+HOMEPAGE = "http://example.com"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
+
+OSTRO_USER_NAME = "appfwtest"
+OSTRO_APP_NAME = "commonapp"
+
+SRC_URI = "file://wrapperapp \
+           file://COPYING.MIT \
+           file://manifest \
+"
+
+inherit ostro-app
+
+S = "${WORKDIR}/"
+
+do_install () {
+    install -d ${D}${OSTRO_APP_ROOT}/bin
+    install -d ${D}${OSTRO_APP_ROOT}/usr/share
+    install -m 0755 wrapperapp  ${D}${OSTRO_APP_ROOT}/bin/
+    install -m 0644 COPYING.MIT ${D}${OSTRO_APP_ROOT}/usr/share/
+    install -m 0644 manifest ${D}${OSTRO_APP_ROOT}/
+}
+
+FILES_${PN} = "${OSTRO_APP_ROOT}/bin/wrapperapp"
+FILES_${PN} =+ "${OSTRO_APP_ROOT}/manifest"
+FILES_${PN} =+ "${OSTRO_APP_ROOT}/usr/share/COPYING.MIT"

--- a/recipes-test/appfw-test-app/files/COPYING.MIT
+++ b/recipes-test/appfw-test-app/files/COPYING.MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/recipes-test/appfw-test-app/files/manifest
+++ b/recipes-test/appfw-test-app/files/manifest
@@ -1,0 +1,17 @@
+{
+    "application": "commonapp",
+    "description": "Common AppFW Test App",
+    "provider": "appfwtest",
+    "groups": "appfwtest-commonapp",
+    "environment": {
+        "KEY1": "value1",
+        "KEY2": "value2",
+    },
+    "command": [ "/bin/wrapperapp" ],
+    "autostart": "false",
+     "container": {
+        "type": "nspawn",
+        "network": "VirtualEthernet",
+        "sharedsystem": false,
+    },
+}

--- a/recipes-test/appfw-test-app/files/wrapperapp
+++ b/recipes-test/appfw-test-app/files/wrapperapp
@@ -1,0 +1,6 @@
+#!/bin/sh
+while true
+do  
+    echo 'Hello Ostro!'
+    sleep 10
+done


### PR DESCRIPTION
The wrapperapp is a shell script, so can use/modify it for more test cases.
