### PR TITLE
bsp.manifest: remove empty line in manifest file

### DIFF
--- a/conf/test/bsp.manifest
+++ b/conf/test/bsp.manifest
@@ -1,3 +1,2 @@
 oeqa.runtime.bsp.bsp
 oeqa.runtime.bsp.galileo_gen2
-


### PR DESCRIPTION
remove empty line in manifest file, otherwise the runner will fail to run.
workaround of bug IOTOS-1447

Signed-off-by: Lei Yang <lei.a.yang@intel.com>