### PR TITLE
meta-iotqa: fix a bug in run_as

### DIFF
--- a/lib/oeqa/utils/helper.py
+++ b/lib/oeqa/utils/helper.py
@@ -89,8 +89,16 @@ def remove_user(username, target=None):
     target = target if target is not None else oeRuntimeTest.tc.target
     return target.run("userdel %s"%username)[0] == 0
 
-def run_as(username, cmd, timeout=None, target=None):
+def escape(s):
+    ret = s.replace(r'"', r'\"')
+    return ret
+
+def run_as(username, cmd, timeout=None, target=None, need_escape=True):
+    """
+    escape: if True, run_as will try to escape some special char. for example: '"$
+    """
     target = target if target is not None else oeRuntimeTest.tc.target
+    cmd = escape(cmd) if need_escape else cmd
     cmd = "su %s -c \"%s\""%(username, cmd)
     return target.run(cmd, timeout) if timeout else target.run(cmd)
     


### PR DESCRIPTION
run_as use {su username -c "cmd"} to run a cmd as username, but when cmd has some characters such as " and $, these character need escape for keep original meaning.
