### PR TITLE
meta-iotqa: fix a hard code issue in test-iot.bbclass

### DIFF
--- a/classes/test-iot.bbclass
+++ b/classes/test-iot.bbclass
@@ -25,7 +25,7 @@
 
 inherit testimage
 #set dependency for test_ostro and test_iot_export
-TESTIMAGEDEPENDS = "ostro-image:do_build"
+TESTIMAGEDEPENDS = "${PN}:do_build"
 DEPLOY_DIR_TESTSUITE ?= "${DEPLOY_DIR}/testsuite"
 
 #get layer dir


### PR DESCRIPTION
when we do export, we use "bitbake xxx-image -c test_iot_export", So maybe we can use a variable for the depends. I choose ${PN}, But I'm not sure this is accurate.
we still don't how to fix the ostro-image.bbappend issue, Does someone can help with this?