### PR TITLE
avoid hacks related to test export

### DIFF
--- a/classes/test-iot.bbclass
+++ b/classes/test-iot.bbclass
@@ -135,8 +135,7 @@ def dump_builddata(d, tdir):
     savedata = {}
     savedata["imagefeatures"] = d.getVar("IMAGE_FEATURES", True).split()
     savedata["distrofeatures"] = d.getVar("DISTRO_FEATURES", True).split()
-    manifest = os.path.join(d.getVar("DEPLOY_DIR_IMAGE", True),
-                              d.getVar("IMAGE_LINK_NAME", True) + ".manifest")
+    manifest = d.getVar("IMAGE_MANIFEST", True)
     try:
         with open(manifest) as f:
             pkgs = f.readlines()

--- a/recipes-image/images/ostro-image.bbappend
+++ b/recipes-image/images/ostro-image.bbappend
@@ -1,5 +1,0 @@
-IOTQA_EXTRA_IMAGEDEPENDS += "mraa-test mmap-smack-test tcp-smack-test udp-smack-test read-map shm-util gdb"
-IOTQA_EXTRA_IMAGEDEPENDS += "${@bb.utils.contains('IMAGE_FEATURES', 'app-privileges', 'app-runas', '', d)}"
-
-EXTRA_IMAGEDEPENDS += "${@bb.utils.contains('IMAGE_FEATURES', 'qatests', '${IOTQA_EXTRA_IMAGEDEPENDS}', '', d)}"
-


### PR DESCRIPTION
This was used already successfully in
https://github.com/ostroproject/ostro-os/pull/25 to build and sanity
test swupd-enabled images. The extra dependencies (like hello_mraa)
were included in iot-testfiles.intel-corei7-64.tar.gz (I checked).

The same changes should also work with current master (untested, to be
tested by the PR's test build), hence this PR. Remember to check
manually that iot-testfiles.intel-corei7-64.tar.gz for the test build
contains hello_mraa!