### PR TITLE
 wifi: add three EFT cases to check 802.11ac and WEP encryption

### DIFF
--- a/lib/oeqa/runtime/wifi/comm_wifi_connect.py
+++ b/lib/oeqa/runtime/wifi/comm_wifi_connect.py
@@ -138,6 +138,54 @@ class CommWiFiConect(oeRuntimeTest):
         self.wifi.execute_connection(ap_type, ssid, pwd)
         self.wifi.check_internet_connection()
 
+    @tag(FeatureID="IOTOS-458")
+    def test_connect_wep(self):
+        '''connmanctl to connect to WEP encryption AP
+        @fn test_connect_wep
+        @param self
+        @return
+        '''
+        ap_type = "hidden"
+        ssid = ssid_config.get("Connect","ssid_wep")
+        pwd = ssid_config.get("Connect","passwd_wep")
+
+        self.wifi.execute_connection(ap_type, ssid, pwd)
+
+    @tag(FeatureID="IOTOS-458")
+    def test_connect_80211ac(self):
+        '''connmanctl to connect to 802.11ac AP
+        @fn test_connect_80211ac
+        @param self
+        @return
+        '''
+        ap_type = "hidden"
+        ssid = ssid_config.get("Connect","ssid_80211ac")
+        pwd = ssid_config.get("Connect","passwd_80211ac")
+
+        self.wifi.execute_connection(ap_type, ssid, pwd)
+
+    @tag(FeatureID="IOTOS-458")
+    def test_connect_save_password(self):
+        '''When connecting to an AP connected before, do not need input password
+        @fn test_connect_save_password
+        @param self
+        @return
+        '''
+        # Connect to 80211n AP firstly
+        ap_type = "hidden"
+        ssid_n = ssid_config.get("Connect","ssid_80211n")
+        pwd_n = ssid_config.get("Connect","passwd_80211n")
+
+        self.wifi.execute_connection(ap_type, ssid_n, pwd_n)
+        # Connect to 80211g AP
+        ssid_g = ssid_config.get("Connect","ssid_80211g")
+        pwd_g = ssid_config.get("Connect","passwd_80211g")
+        self.wifi.execute_connection(ap_type, ssid_g, pwd_g)
+
+        # Then, connect back to 80211n, without inputting password
+        self.wifi.connect_without_password(ssid_n)
+        
+
 ##
 # @}
 # @}

--- a/lib/oeqa/runtime/wifi/comm_wifi_connect.py
+++ b/lib/oeqa/runtime/wifi/comm_wifi_connect.py
@@ -138,7 +138,7 @@ class CommWiFiConect(oeRuntimeTest):
         self.wifi.execute_connection(ap_type, ssid, pwd)
         self.wifi.check_internet_connection()
 
-    @tag(FeatureID="IOTOS-458")
+    @tag(TestType="EFT", FeatureID="IOTOS-458")
     def test_connect_wep(self):
         '''connmanctl to connect to WEP encryption AP
         @fn test_connect_wep
@@ -151,7 +151,7 @@ class CommWiFiConect(oeRuntimeTest):
 
         self.wifi.execute_connection(ap_type, ssid, pwd)
 
-    @tag(FeatureID="IOTOS-458")
+    @tag(TestType="EFT", FeatureID="IOTOS-458")
     def test_connect_80211ac(self):
         '''connmanctl to connect to 802.11ac AP
         @fn test_connect_80211ac
@@ -164,7 +164,7 @@ class CommWiFiConect(oeRuntimeTest):
 
         self.wifi.execute_connection(ap_type, ssid, pwd)
 
-    @tag(FeatureID="IOTOS-458")
+    @tag(TestType="EFT", FeatureID="IOTOS-458")
     def test_connect_save_password(self):
         '''When connecting to an AP connected before, do not need input password
         @fn test_connect_save_password

--- a/lib/oeqa/runtime/wifi/files/wifi_connect.exp
+++ b/lib/oeqa/runtime/wifi/files/wifi_connect.exp
@@ -1,5 +1,6 @@
 #!/usr/bin/expect
 set timeout 100
+set retry 0
 set login 0
 set ip       [lindex $argv 0]
 set cmd      [lindex $argv 1]
@@ -11,19 +12,19 @@ spawn ssh root@$ip -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -
  "Agent registered"
    {
     send "config $service --remove\n";
-    sleep 2; send "connect $service\n"; exp_continue
+    if {$retry < 4} {incr retry; sleep 1; send "connect $service\n"; exp_continue} else {send "exit\n"; exit 3}
    }
  "Operation timeout"
    {
-    sleep 1; send "connect $service\n"; exp_continue
+    if {$retry < 4} {incr retry; sleep 1; send "connect $service\n"; exp_continue} else {send "exit\n"; exit 3}
    }
  "Operation aborted"
    {
-    sleep 1; send "connect $service\n"; exp_continue
+    if {$retry < 4} {incr retry; sleep 1; send "connect $service\n"; exp_continue} else {send "exit\n"; exit 3}
    }
  "Input/output error"
    {
-    sleep 1; send "connect $service\n"; exp_continue
+    if {$retry < 4} {incr retry; sleep 1; send "connect $service\n"; exp_continue} else {send "exit\n"; exit 3}
    }
  "Retry (yes/no)?"
    {

--- a/lib/oeqa/runtime/wifi/files/wifi_hidden_connect.exp
+++ b/lib/oeqa/runtime/wifi/files/wifi_hidden_connect.exp
@@ -1,6 +1,7 @@
 #!/usr/bin/expect
 set timeout 100
 set login 0
+set retry 0
 set ip       [lindex $argv 0]
 set cmd      [lindex $argv 1]
 set service  [lindex $argv 2]
@@ -11,15 +12,15 @@ spawn ssh root@$ip -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -
  expect {
  "Agent registered"
    {
-    sleep 1; send "connect $service\n"; exp_continue
+    if {$retry < 4} {incr retry; sleep 1; send "connect $service\n"; exp_continue} else {send "exit\n"; exit 3}
    }
  "Operation timeout"
    {
-    sleep 1; send "connect $service\n"; exp_continue
+    if {$retry < 4} {incr retry; sleep 1; send "connect $service\n"; exp_continue} else {send "exit\n"; exit 3}
    }
  "Input/output error"
    {
-    sleep 1; send "connect $service\n"; exp_continue
+    if {$retry < 4} {incr retry; sleep 1; send "connect $service\n"; exp_continue} else {send "exit\n"; exit 3}
    }
  "Hidden SSID name?"
    {


### PR DESCRIPTION
Although WiFi feature does not ask, the 802.11ac (5GHz) WiFi AP and
old WEP encryption are commonly used by user. Desgin 2 cases to
test them.
Add another 1 case to check WiFi password remember function. When
doing second time connection, it does not need to input password.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>