### PR TITLE
[restapi] Remove tests about api/oic/p

### DIFF
--- a/lib/oeqa/runtime/nodejs/rest_apis.py
+++ b/lib/oeqa/runtime/nodejs/rest_apis.py
@@ -38,8 +38,8 @@ class RESTAPITest(oeRuntimeTest):
 
         'api_system': 'nodeunit_test_api_system.js',
         'api_oic_d': 'nodeunit_test_api_oic_d.js',
-        'api_oic_p': 'nodeunit_test_api_oic_p.js',
-        'api_oic_res': 'nodeunit_test_api_oic_res.js',
+        #'api_oic_p': 'nodeunit_test_api_oic_p.js',
+        'api_oic_res': 'nodeunit_test_api_oic_res.js'
 
     }
 
@@ -992,340 +992,340 @@ class RESTAPITest(oeRuntimeTest):
         self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_status_code(self):
-        '''
-        Test status code of /api/oic/p.
-        @fn test_api_oic_p_status_code
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPStatusCode' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_status_code
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_status_code
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_status_code(self):
+    #     '''
+    #     Test status code of /api/oic/p.
+    #     @fn test_api_oic_p_status_code
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPStatusCode' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_status_code
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_status_code
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_has_required_pi(self):
-        '''
-        Test if the response of /api/oic/pi has required property pi.
-        @fn test_api_oic_p_has_required_pi
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredPiNotNull' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_has_required_pi
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_has_required_pi
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_has_required_pi(self):
+    #     '''
+    #     Test if the response of /api/oic/pi has required property pi.
+    #     @fn test_api_oic_p_has_required_pi
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredPiNotNull' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_has_required_pi
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_has_required_pi
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_required_pi_type(self):
-        '''
-        Test if the type of pi property in response is string.
-        @fn test_api_oic_p_required_pi_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredPiType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_required_pi_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_required_pi_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_required_pi_type(self):
+    #     '''
+    #     Test if the type of pi property in response is string.
+    #     @fn test_api_oic_p_required_pi_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredPiType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_required_pi_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_required_pi_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_has_required_mnmn(self):
-        '''
-        Test if the response of /api/oic/p has required property mnmn.
-        @fn test_api_oic_p_has_required_mnmn
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredMnmnNotNull' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_has_required_mnmn
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_has_required_mnmn
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_has_required_mnmn(self):
+    #     '''
+    #     Test if the response of /api/oic/p has required property mnmn.
+    #     @fn test_api_oic_p_has_required_mnmn
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredMnmnNotNull' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_has_required_mnmn
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_has_required_mnmn
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_required_mnmn_type(self):
-        '''
-        Test if the type of mnmn property in response is string.
-        @fn test_api_oic_p_required_mnmn_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredMnmnType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_required_mnmn_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_required_mnmn_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_required_mnmn_type(self):
+    #     '''
+    #     Test if the type of mnmn property in response is string.
+    #     @fn test_api_oic_p_required_mnmn_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredMnmnType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_required_mnmn_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_required_mnmn_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_mnml_type(self):
-        '''
-        Test if the type of mnml property in response is string.
-        @fn test_api_oic_p_optional_mnml_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnmlType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_mnml_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_mnml_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_mnml_type(self):
+    #     '''
+    #     Test if the type of mnml property in response is string.
+    #     @fn test_api_oic_p_optional_mnml_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnmlType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_mnml_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_mnml_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_mnmo_type(self):
-        '''
-        Test if the type of mnmo property in response is string.
-        @fn test_api_oic_p_optional_mnmo_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnmoType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_mnmo_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_mnmo_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_mnmo_type(self):
+    #     '''
+    #     Test if the type of mnmo property in response is string.
+    #     @fn test_api_oic_p_optional_mnmo_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnmoType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_mnmo_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_mnmo_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_mndt_type(self):
-        '''
-        Test if the type of mndt property in response is string.
-        @fn test_api_oic_p_optional_mndt_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMndtType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_mndt_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_mndt_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_mndt_type(self):
+    #     '''
+    #     Test if the type of mndt property in response is string.
+    #     @fn test_api_oic_p_optional_mndt_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMndtType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_mndt_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_mndt_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_mnpv_type(self):
-        '''
-        Test if the type of mnpv property in response is string.
-        @fn test_api_oic_p_optional_mnpv_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnpvType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_mnpv_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_mnpv_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_mnpv_type(self):
+    #     '''
+    #     Test if the type of mnpv property in response is string.
+    #     @fn test_api_oic_p_optional_mnpv_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnpvType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_mnpv_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_mnpv_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_mnos_type(self):
-        '''
-        Test if the type of mnos property in response is string.
-        @fn test_api_oic_p_optional_mnos_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnosType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_mnos_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_mnos_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_mnos_type(self):
+    #     '''
+    #     Test if the type of mnos property in response is string.
+    #     @fn test_api_oic_p_optional_mnos_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnosType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_mnos_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_mnos_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_mnhw_type(self):
-        '''
-        Test if the type of mnhw property in response is string.
-        @fn test_api_oic_p_optional_mnhw_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnhwType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_mnhw_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_mnhw_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_mnhw_type(self):
+    #     '''
+    #     Test if the type of mnhw property in response is string.
+    #     @fn test_api_oic_p_optional_mnhw_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnhwType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_mnhw_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_mnhw_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_mnfv_type(self):
-        '''
-        Test if the type of mnfv property in response is string.
-        @fn test_api_oic_p_optional_mnfv_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnfvType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_mnfv_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_mnfv_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_mnfv_type(self):
+    #     '''
+    #     Test if the type of mnfv property in response is string.
+    #     @fn test_api_oic_p_optional_mnfv_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnfvType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_mnfv_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_mnfv_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_mnsl_type(self):
-        '''
-        Test if the type of mnfv property in response is string.
-        @fn test_api_oic_p_optional_mnsl_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnslType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_mnsl_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_mnsl_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_mnsl_type(self):
+    #     '''
+    #     Test if the type of mnfv property in response is string.
+    #     @fn test_api_oic_p_optional_mnsl_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnslType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_mnsl_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_mnsl_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    def test_api_oic_p_optional_st_type(self):
-        '''
-        Test if the type of st property in response is string.
-        @fn test_api_oic_p_optional_st_type
-        @param self
-        @return
-        '''
-        (api_status, api_output) = self.target.run(
-                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalStType' % (
-                    self.target_rest_api_dir,
-                    self.target_rest_api_dir,
-                    self.rest_api_js_files['api_oic_p']
-                   )
-        )
-        ##
-        # TESTPOINT: #1, test_api_oic_p_optional_st_type
-        #
-        self.assertEqual(api_status, 0)
-        ##
-        # TESTPOINT: #2, test_api_oic_p_optional_st_type
-        #
-        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    # def test_api_oic_p_optional_st_type(self):
+    #     '''
+    #     Test if the type of st property in response is string.
+    #     @fn test_api_oic_p_optional_st_type
+    #     @param self
+    #     @return
+    #     '''
+    #     (api_status, api_output) = self.target.run(
+    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalStType' % (
+    #                 self.target_rest_api_dir,
+    #                 self.target_rest_api_dir,
+    #                 self.rest_api_js_files['api_oic_p']
+    #                )
+    #     )
+    #     ##
+    #     # TESTPOINT: #1, test_api_oic_p_optional_st_type
+    #     #
+    #     self.assertEqual(api_status, 0)
+    #     ##
+    #     # TESTPOINT: #2, test_api_oic_p_optional_st_type
+    #     #
+    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
     def test_api_oic_res_status_code(self):


### PR DESCRIPTION
- The feature about api/oic/p will support in a new separate requirement(IOTOS-1490), but not in 1.0

Releate to: IOTOS-1184

Signed-off-by: Wang Hongjuan <hongjuan.wang@intel.com>