### PR TITLE
can: automate 2 FVT cases

### DIFF
--- a/conf/test/can.manifest
+++ b/conf/test/can.manifest
@@ -1,0 +1,1 @@
+oeqa.runtime.can.comm_can_basic

--- a/conf/test/manual.csv
+++ b/conf/test/manual.csv
@@ -10,9 +10,6 @@ TestStep,,,,4,"Write new value into the handle by:
 gatttool -b <iot BT MAC> --char-write-req -a <handle> -n abcd",return write success,,,,,,,
 TestStep,,,,5,"Read this handle again.
 gatttool -b <iot BT MAC> --char-read -a <handle>",the value has been modified to 'ab cd ...',,,,,,,
-TestScript,comm_can_can0,COMMS/CAN,enable CAN bus to recognize can0,1,Run ifconfig after system boots up.,There should be 'can0' interface,FVT,ready,IOTOS-385,,,,
-TestScript,comm_can_data_dump,COMMS/CAN,send data to can0 and dump data,1,Send message to can0 bus. Command is: ./cansend can0 500#1E.10.10,command return 0 (success),FVT,ready,IOTOS-385,,,,
-TestStep,,,,2,"In another terminal, receive message on can0: Command is: ./candump can0","It will print ""can0 500 [3] 1E 10 10""",,,,,,,
 TestScript,comm_rs232_debugging,COMMS/rs232,connect rs232 cable for debugging,1,Plug RS232 cable to the main-board,,FVT,ready,IOTOS-379,,,,
 TestStep,,,,2,Check by minicom on PC to get the debugging output,info could be output on minicom,,,,,,,
 TestScript,comm_rs232_usb_to_serial,COMMS/rs232,Plug usb port to IoT and plug rs232 to PC,1,Plug usb port to IoT device ,,FVT,ready,IOTOS-381,,,,

--- a/lib/oeqa/runtime/can/can.py
+++ b/lib/oeqa/runtime/can/can.py
@@ -1,0 +1,89 @@
+"""
+@file can.py
+"""
+
+##
+# @addtogroup sanity sanity
+# @brief This is sanity component
+# @{
+# @addtogroup comm_can
+# @brief This is comm_can
+# @{
+##
+
+import time
+import os
+import string
+from oeqa.utils.helper import shell_cmd_timeout
+
+class CANFunction(object):
+    """
+    @class CANFunction
+    """
+    log = ""
+    def __init__(self, target):
+        self.target = target
+
+    def target_collect_info(self, cmd):
+        """
+        @fn target_collect_info
+        @param self
+        @param  cmd
+        @return
+        """
+        (status, output) = self.target.run(cmd)
+        self.log = self.log + "\n\n[Debug] Command output --- %s: \n" % cmd
+        self.log = self.log + output
+
+    def enable_can(self):
+        """
+        @fn enable_can
+        @param self
+        @return
+        """
+        # Check if the can-usb is recognized at system boot up
+        (status, output) = self.target.run('ifconfig -a')
+        if 'can0' not in output:
+            # try to use scland to create can0 (for some CAN232 and CANUSBdevices)
+            (status, output) = self.target.run('slcand -o -c -f -F /dev/ttyUSB0 can0 > /dev/null 2&>1 &')
+            assert status == 0, "Error messages: %s" % output 
+
+        (status, output) = self.target.run('ifconfig can0 up')
+        assert status == 0, "Error messages: %s" % output
+        time.sleep(1)
+
+    def disable_can(self):
+        ''' disable can0 after testing 
+        @fn disable_can
+        @param self
+        @return
+        '''
+        (status, output) = self.target.run('ifconfig can0 down')
+        assert status == 0, "Error messages: %s" % output 
+        (status, output) = self.target.run('killall slcand')
+        # sleep some seconds to ensure disable is done
+        time.sleep(1)
+
+    def send_data(self):
+        """
+        @fn send_data
+        @param self
+        """
+        # after 10 seconds, send data to can-bus
+        self.target.run('candump can0 > /tmp/can-log 2>&1 &')
+        time.sleep(1)
+        (status, output) = self.target.run('cansend can0 500#1E.10.11.10')
+        assert status == 0, "cansend command fails: %s" % output
+        # Check can-dump output
+        self.target.run('killall candump')
+        (status, output) = self.target.run('cat /tmp/can-log')
+        if 'can0  500' in output:
+            pass
+        else:
+            assert False, "can-dump does not get data: %s %s" % (output, self.log)
+
+##
+# @}
+# @}
+##
+

--- a/lib/oeqa/runtime/can/comm_can_basic.py
+++ b/lib/oeqa/runtime/can/comm_can_basic.py
@@ -1,0 +1,63 @@
+"""
+@file comm_can_basic.py
+"""
+
+##
+# @addtogroup can
+# @brief This is component
+# @{
+# @addtogroup comm_can
+# @brief This is comm_can
+# @{
+##
+
+import can
+from oeqa.oetest import oeRuntimeTest
+from oeqa.utils.decorators import tag
+
+@tag(TestType="FVT")
+class CommCAN(oeRuntimeTest):
+    """
+    @class CommCAN
+    """
+    def setUp(self):
+        ''' initialize can class 
+        @fn setUp
+        @param self
+        @return
+        '''
+        self.can = can.CANFunction(self.target)
+
+    def tearDown(self):
+        ''' disable after testing 
+        @fn tearDown
+        @param self
+        @return
+        '''
+        # disable wifi
+        self.can.disable_can()
+
+    @tag(FeatureID="IOTOS-385")
+    def test_enable_can0(self):
+        '''Enable can0 interface on device
+        @fn test_enable_can0
+        @param self
+        @return
+        '''
+        self.can.enable_can()
+
+    @tag(FeatureID="IOTOS-385")
+    def test_can_send_data(self):
+        '''Send data to can bus
+        @fn test_can_send_data
+        @param self
+        @return
+        '''
+        self.can.enable_can()
+        self.can.send_data()
+
+##
+# @}
+# @}
+##
+


### PR DESCRIPTION
can-bus was supported before M2, at that time we have manual cases.
Now, the two manual cases are automated.
1st is to enable can0 interface in ifconfig.
2nd is to send data to can-bus.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>