### PR TITLE
ethernet: fix case bugs IOTOS-1419 and IOTOS-1494

### DIFF
--- a/lib/oeqa/runtime/ethernet/files/config.ini
+++ b/lib/oeqa/runtime/ethernet/files/config.ini
@@ -1,2 +1,0 @@
-[Ethernet]
-interface=eth1


### PR DESCRIPTION
IOTOS-1419, automatically detect Host ethernet interface for IoT
IOTOS-1494, some scenario although device is not connected, case
still passes unexpectedly. It is due to get_ipv6() has no checking.
Add a non-blank checking to the function when return.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>