### PR TITLE
python: change folder name from python to pythonruntime

### DIFF
--- a/lib/oeqa/runtime/pythonruntime/apprt_python_runtime.py
+++ b/lib/oeqa/runtime/pythonruntime/apprt_python_runtime.py
@@ -138,8 +138,6 @@ def write_tc_result(tc_result, tc):
         tc.append('PASSED')
     elif 'FAIL' in tc_result or 'fail' in tc_result:
         tc.append('FAILED')
-    elif 'skipped' in tc_result or 'SKIPPED' in tc_result:
-        tc.append('SKIPPED')
     elif 'ERROR' in tc_result or 'error' in tc_result:
         tc.append('ERROR')
     else:


### PR DESCRIPTION
Change python runtime case folder name, for there is another python.py
Fix bug IOTOS-1413, to remove SKIP results from python-runtime.log

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>