### PR TITLE
case_interface.py: strip casename

### DIFF
--- a/lib/oeqa/utils/case_interface.py
+++ b/lib/oeqa/utils/case_interface.py
@@ -36,6 +36,7 @@ class TestCaseInterface(oeRuntimeTest):
         ori(self, FakeResult(), *args, **kwargs)
 
     def addSuccess(self, casename, classname=None, stdout="", stderr=""):
+        casename = casename.strip()
         classname = classname if classname else casename
         def testFake(self):
             sys.stdout.write(stdout)
@@ -44,6 +45,7 @@ class TestCaseInterface(oeRuntimeTest):
         obj.run(self.result)
 
     def addError(self, casename, classname=None, stdout="", stderr=""):
+        casename = casename.strip()
         classname = classname if classname else casename
         def testFake(self):
             sys.stdout.write(stdout)
@@ -53,6 +55,7 @@ class TestCaseInterface(oeRuntimeTest):
         obj.run(self.result)
 
     def addFailure(self, casename, classname=None, stdout="", stderr=""):
+        casename = casename.strip()
         classname = classname if classname else casename
         def testFake(self):
             sys.stdout.write(stdout)
@@ -62,6 +65,7 @@ class TestCaseInterface(oeRuntimeTest):
         obj.run(self.result)
 
     def addSkip(self, casename, classname=None, stdout="", stderr=""):
+        casename = casename.strip()
         classname = classname if classname else casename
         def testFake(self):
             sys.stdout.write(stdout)


### PR DESCRIPTION
If the case name includes space, it will fail to generate fail in test results log.
Fix it by strip case name string.

[skip-ci]

Signed-off-by: Lei Yang <lei.a.yang@intel.com>