### PR TITLE
comms: put all the newly adding cases into individual manifest

### DIFF
--- a/conf/test/iotivity.manifest
+++ b/conf/test/iotivity.manifest
@@ -1,1 +1,3 @@
 oeqa.runtime.iotivity.iotvt_integration
+oeqa.runtime.iotivity.iotvt_integration_mnode
+oeqa.runtime.iotivity.iotvt_wifi

--- a/conf/test/wifi.manifest
+++ b/conf/test/wifi.manifest
@@ -1,1 +1,3 @@
 oeqa.runtime.wifi.comm_wifi_connect
+oeqa.runtime.wifi.comm_wifi_mnode.CommWiFiMNode.test_wifi_ssh
+oeqa.runtime.wifi.comm_wifi_mnode.CommWiFiMNode.test_wifi_scp_file

--- a/conf/test/zigbee.manifest
+++ b/conf/test/zigbee.manifest
@@ -1,3 +1,4 @@
 #this is only for Galileo and MinnowMax
 oeqa.runtime.zigbee.comm_zigbee_basic
 oeqa.runtime.zigbee.comm_zigbee_mnode
+oeqa.runtime.zigbee.comm_zigbee_cc2520

--- a/lib/oeqa/runtime/bluetooth/bluetooth.py
+++ b/lib/oeqa/runtime/bluetooth/bluetooth.py
@@ -239,6 +239,7 @@ class BTFunction(object):
         # ssh root@<ipv6 address>%bt0
         ssh_key = os.path.join(os.path.dirname(__file__), "files/ostro_qa_rsa")
         self.target.copy_to(ssh_key, "/tmp/")        
+        self.target.run("chmod 400 /tmp/ostro_qa_rsa")        
 
         exp = os.path.join(os.path.dirname(__file__), "files/target_ssh.exp")
         exp_cmd = 'expect %s %s %s' % (exp, self.target.ip, ipv6)

--- a/lib/oeqa/runtime/bluetooth/comm_bt_6lowpan.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_6lowpan.py
@@ -1,5 +1,5 @@
 """
-@file comm_bt_command.py
+@file comm_bt_6lowpan.py
 """
 
 ##
@@ -19,9 +19,9 @@ from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.decorators import tag
 
 @tag(TestType="FVT")
-class CommBTTest(oeRuntimeTest):
+class CommBT6LowPAN(oeRuntimeTest):
     """
-    @class CommBTTest
+    @class CommBT6LowPAN
     """
     def setUp(self):
         """

--- a/lib/oeqa/runtime/bluetooth/comm_bt_6lowpan_mnode.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_6lowpan_mnode.py
@@ -21,7 +21,7 @@ from oeqa.utils.decorators import tag
 @tag(TestType="EFT")
 class CommBT6LowPanMNode(oeRuntimeTest):
     """
-    @class CommBTTest
+    @class CommBT6LowPanMNode
     """
     def setUp(self):
         """

--- a/lib/oeqa/runtime/bluetooth/comm_bt_command_mnode.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_command_mnode.py
@@ -1,5 +1,5 @@
 """
-@file comm_bt_command.py
+@file comm_bt_command_mnode.py
 """
 
 ##
@@ -21,9 +21,9 @@ from oeqa.utils.helper import get_files_dir
 from oeqa.utils.decorators import tag
 
 @tag(TestType="FVT")
-class CommBTTest(oeRuntimeTest):
+class CommBTTestMNode(oeRuntimeTest):
     """
-    @class CommBTTest
+    @class CommBTTestMNode
     """
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Besides fullauto and iottest (sanity) manifest, we need to ensure
individual domain manifest has all cases. So, add them into the
domain.manifest files. Fix typo class name in Bluetooth domain, which
would make some case missed in final result.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>