### PR TITLE
wifi and bluetooth: fix bug for doing ssh on IoT target

### DIFF
--- a/lib/oeqa/runtime/bluetooth/files/target_ssh.exp
+++ b/lib/oeqa/runtime/bluetooth/files/target_ssh.exp
@@ -4,7 +4,7 @@ set login 0
 set ip4      [lindex $argv 0]
 set ip6      [lindex $argv 1]
 
-spawn ssh root@$ip4 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR ssh root@$ip6%bt0 -i /tmp/ostro_qa_rsa ls /
+spawn ssh root@$ip4 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR
  expect {
  "yes/no"
    {
@@ -13,6 +13,11 @@ spawn ssh root@$ip4 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no 
  "home"
    {
     sleep 1; send "exit\n"; exit 2
+   }
+ "#"
+   {
+    sleep 1;
+    if {$login==0} {set login 1; send "ssh root@$ip6%bt0 -i /tmp/ostro_qa_rsa ls /\n"; exp_continue} else {exp_continue}
    }
  eof
    {}

--- a/lib/oeqa/runtime/wifi/files/ssh_to.exp
+++ b/lib/oeqa/runtime/wifi/files/ssh_to.exp
@@ -1,9 +1,10 @@
 #!/usr/bin/expect
 set timeout 60
+set condition  0
 set first      [lindex $argv 0]
 set second     [lindex $argv 1]
 
-spawn ssh root@$first -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR ssh root@$second -i /tmp/ostro_qa_rsa ls /
+spawn ssh root@$first -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR
  expect {
  "yes/no"
    {
@@ -12,6 +13,11 @@ spawn ssh root@$first -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=n
  "home"
    {
     sleep 1; send "exit\n"; exit 2
+   }
+ "#"
+   {
+    sleep 1;
+    if {$condition==0} {set condition 1; send "ssh -i /tmp/ostro_qa_rsa root@$second ls /\n"; exp_continue} else {exp_continue}
    }
  eof
    {}

--- a/lib/oeqa/runtime/wifi/wifi.py
+++ b/lib/oeqa/runtime/wifi/wifi.py
@@ -199,6 +199,7 @@ class WiFiFunction(object):
         '''
         ssh_key = os.path.join(os.path.dirname(__file__), "../bluetooth/files/ostro_qa_rsa")
         self.target.copy_to(ssh_key, "/tmp/")
+        self.target.run("chmod 400 /tmp/ostro_qa_rsa")
 
         exp = os.path.join(os.path.dirname(__file__), "files/ssh_to.exp")
         exp_cmd = 'expect %s %s %s' % (exp, self.target.ip, ipv4)


### PR DESCRIPTION
In 2 BT and 2 WiFi cases, we need to do ssh to another device. The
expect file has "Host key verification failed." error, fix it by
adding 400 mode to ssh_key file and changing expect steps.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>