### PR TITLE
test_gplv3_free_image.sh

### DIFF
--- a/conf/test/utils/test_gplv3_free_image.sh
+++ b/conf/test/utils/test_gplv3_free_image.sh
@@ -97,7 +97,7 @@ echo "Check image manifest file to ensure the components are not built-in"
 TC_RESULT="PASS"
 for comp in ${COMPONENT_LIST[@]}; do
     echo "===  check $comp ==="
-    cat "$1" | grep -w "$comp"
+    cat "$1" | grep "$comp"
     [ $? -eq 0 ] && TC_RESULT="FAIL?" &&  echo "found suspected GPL/Less GPL/Affero GPL v3.0 component, need manual check"
 done
 echo "TEST_$TC_RESULT"


### PR DESCRIPTION
previously, it use "grep -w" to filter the violated package name.
however, this will skip some component for example libreadline6
(the component name in license web page is "readline"), which is
GPLv3 violated.
remove "grep -w" will increase the efforts of manual check.

[skip-ci]

Signed-off-by: Lei Yang <lei.a.yang@intel.com>