### PR TITLE
Add test app for gcc OpenMP feature

### DIFF
--- a/recipes-test/openmp-app/openmp-app.bb
+++ b/recipes-test/openmp-app/openmp-app.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "Test OpenMP support functionality"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://openmp-app.c"
+
+S = "${WORKDIR}"
+
+do_configure() {
+}
+
+do_compile() {
+	${CC} ${CFLAGS} -fopenmp -o ${WORKDIR}/openmp-app ${S}/openmp-app.c
+}
+
+do_install() {
+	install -m 0755 -d ${D}${bindir}
+	install -m 0755 ${WORKDIR}/openmp-app ${D}${bindir}
+}
+

--- a/recipes-test/openmp-app/openmp-app/openmp-app.c
+++ b/recipes-test/openmp-app/openmp-app/openmp-app.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Intel Corporation
+ *
+ * Contact: Jussi Laako <jussi.laako@linux.intel.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <omp.h>
+
+int main ()
+{
+	int i;
+	int r = 0;
+	static const int N = 4096;
+	int x[N];
+
+	printf("Number of threads in the pool: %d\n", omp_get_max_threads());
+	printf("Number of processors: %d\n", omp_get_num_procs());
+
+	puts("Running test loop...");
+#	pragma omp parallel for schedule(dynamic)
+	for (i = 0; i < N; i++)
+	{
+		x[i] = N / 2 - i;
+	}
+	puts("...done - verifying...");
+	for (i = 0; i < N; i++)
+	{
+		if (x[i] != (N / 2 - i))
+		{
+			printf("Failure on index %d\n", i);
+			r = -1;
+		}
+	}
+	if (!r) puts("OK");
+
+	return r;
+}
+


### PR DESCRIPTION
This builds a small test application to test functionality of gcc's
OpenMP support.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>