### PR TITLE
python: modify python.manifest to work for new case folder name

### DIFF
--- a/conf/test/python.manifest
+++ b/conf/test/python.manifest
@@ -1,1 +1,1 @@
-oeqa.runtime.python.apprt_python_runtime
+oeqa.runtime.pythonruntime.apprt_python_runtime


### PR DESCRIPTION
weeks ago, the python folder name was changed to pythonruntime,
only the fulltest.manifest files were modified. Now, modify the
python.manifest.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>