### PR TITLE
bluez5, systemd: avoid assumptions about build dir

### DIFF
--- a/recipes-test/ble-tool/bluez5_%.bbappend
+++ b/recipes-test/ble-tool/bluez5_%.bbappend
@@ -1,2 +1,2 @@
 inherit deploy-files
-DEPLOY_FILES_FROM[target] = "${WORKDIR}/bluez-${PV}/attrib/gatttool"
+DEPLOY_FILES_FROM[target] = "${B}/attrib/gatttool"

--- a/recipes-test/systemd/systemd_%.bbappend
+++ b/recipes-test/systemd/systemd_%.bbappend
@@ -1,2 +1,2 @@
 inherit deploy-files
-DEPLOY_FILES_FROM[target] = "${WORKDIR}/build/systemd-analyze"
+DEPLOY_FILES_FROM[target] = "${B}/systemd-analyze"


### PR DESCRIPTION
@testkit: please review soon, the problem with Bluez is preventing
the update to recent OE-core master.