### PR TITLE
comms: improve stability for BT/WiFi/Ethernet/Iotivity

### DIFF
--- a/lib/oeqa/runtime/bluetooth/comm_bt_command_mnode.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_command_mnode.py
@@ -57,7 +57,7 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        for i in range(1, 4):
+        for i in range(3):
             self.bt2.target_hciconfig_init()
             self.bt2.set_leadv()
             (status, output) = self.bt1.gatt_basic_check(self.bt2.get_bt_mac(), 'primary')
@@ -73,7 +73,7 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        for i in range(1, 4):
+        for i in range(3):
             self.bt2.target_hciconfig_init()
             self.bt2.set_leadv()
             (status, output) = self.bt1.gatt_basic_check(self.bt2.get_bt_mac(), 'characteristics')
@@ -89,7 +89,7 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        for i in range(1, 4):
+        for i in range(3):
             self.bt2.target_hciconfig_init()
             self.bt2.set_leadv()
             (status, output) = self.bt1.gatt_basic_check(self.bt2.get_bt_mac(), 'handle')
@@ -105,7 +105,7 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        for i in range(1, 4):
+        for i in range(3):
             self.bt2.target_hciconfig_init()
             self.bt2.set_leadv()
             (status, output) = self.bt1.gatt_basic_check(self.bt2.get_bt_mac(), 'connect')
@@ -121,7 +121,7 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        for i in range(1, 4):
+        for i in range(3):
             self.bt1.target_hciconfig_init()
             self.bt1.set_leadv()
             (status, output) = self.bt2.gatt_basic_check(self.bt1.get_bt_mac(), 'primary')
@@ -137,7 +137,7 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        for i in range(1, 4):
+        for i in range(3):
             self.bt1.target_hciconfig_init()
             self.bt1.set_leadv()
             (status, output) = self.bt2.gatt_basic_check(self.bt1.get_bt_mac(), 'characteristics')
@@ -153,7 +153,7 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        for i in range(1, 4):
+        for i in range(3):
             self.bt1.target_hciconfig_init()
             self.bt1.set_leadv()
             (status, output) = self.bt2.gatt_basic_check(self.bt1.get_bt_mac(), 'handle')
@@ -169,7 +169,7 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        for i in range(1, 4):
+        for i in range(3):
             self.bt1.target_hciconfig_init()
             self.bt1.set_leadv()
             (status, output) = self.bt2.gatt_basic_check(self.bt1.get_bt_mac(), 'connect')
@@ -186,10 +186,13 @@ class CommBTTestMNode(oeRuntimeTest):
         @return
         '''
         self.bt1.target.run('hciconfig hci0 noleadv')
-        # For init function already set visible status, directly be scanned.  
-        exp = os.path.join(os.path.dirname(__file__), "files/bt_scan.exp")
-        cmd = "expect %s %s %s" % (exp, self.bt2.target.ip, self.bt1.get_bt_mac())
-        status, output = shell_cmd_timeout(cmd, timeout=100)
+        for i in range(3):
+            # For init function already set visible status, directly be scanned.  
+            exp = os.path.join(os.path.dirname(__file__), "files/bt_scan.exp")
+            cmd = "expect %s %s %s" % (exp, self.bt2.target.ip, self.bt1.get_bt_mac())
+            status, output = shell_cmd_timeout(cmd, timeout=100)
+            if status == 2:
+                break
         self.assertEqual(status, 2, msg="Scan remote device fails: %s" % output) 
 
     @tag(FeatureID="IOTOS-456")
@@ -200,10 +203,13 @@ class CommBTTestMNode(oeRuntimeTest):
         @return
         '''
         self.bt2.target.run('hciconfig hci0 noleadv')
-        # For init function already set visible status, directly be scanned.  
-        exp = os.path.join(os.path.dirname(__file__), "files/bt_scan.exp")
-        cmd = "expect %s %s %s" % (exp, self.bt1.target.ip, self.bt2.get_bt_mac())
-        status, output = shell_cmd_timeout(cmd, timeout=100)
+        for i in range(3):
+            # For init function already set visible status, directly be scanned.  
+            exp = os.path.join(os.path.dirname(__file__), "files/bt_scan.exp")
+            cmd = "expect %s %s %s" % (exp, self.bt1.target.ip, self.bt2.get_bt_mac())
+            status, output = shell_cmd_timeout(cmd, timeout=100)
+            if status == 2:
+                break
         self.assertEqual(status, 2, msg="Scan remote device fails: %s" % output) 
 
     @tag(FeatureID="IOTOS-759")
@@ -213,15 +219,21 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        # close legacy iscan mode
-        self.bt1.target.run('hciconfig hci0 noscan')
-        # begin low-energy scan
-        self.bt1.target.run('hciconfig hci0 leadv')
-        time.sleep(1)
-        # Another device starts bluetoothctl to scan target 
-        exp = os.path.join(os.path.dirname(__file__), "files/bt_scan.exp")
-        cmd = "expect %s %s %s" % (exp, self.bt2.target.ip, self.bt1.get_bt_mac())
-        status, output = shell_cmd_timeout(cmd, timeout=100)
+        for i in range(3):
+            # close legacy iscan mode
+            self.bt1.target.run('hciconfig hci0 noscan')
+            # begin low-energy scan
+            self.bt1.target.run('hciconfig hci0 leadv')
+            time.sleep(1)
+            # Another device starts bluetoothctl to scan target 
+            exp = os.path.join(os.path.dirname(__file__), "files/bt_scan.exp")
+            cmd = "expect %s %s %s" % (exp, self.bt2.target.ip, self.bt1.get_bt_mac())
+            status, output = shell_cmd_timeout(cmd, timeout=100)
+            if status == 2:
+                break
+            else:
+                self.bt1.target.run('hciconfig hci0 reset')
+                time.sleep(3)
         self.assertEqual(status, 2, msg="Be LE-scanned fails: %s" % output) 
 
     @tag(FeatureID="IOTOS-770")
@@ -231,16 +243,21 @@ class CommBTTestMNode(oeRuntimeTest):
         @param self
         @return
         '''
-        # close legacy iscan mode
-        self.bt2.target.run('hciconfig hci0 noscan')
-        # begin low-energy scan
-        self.bt2.target.run('hciconfig hci0 leadv')
-        time.sleep(1)
-
-        # Device starts bluetoothctl to scan others 
-        exp = os.path.join(os.path.dirname(__file__), "files/bt_scan.exp")
-        cmd = "expect %s %s %s" % (exp, self.bt1.target.ip, self.bt2.get_bt_mac())
-        status, output = shell_cmd_timeout(cmd, timeout=100)
+        for i in range(3):
+            # close legacy iscan mode
+            self.bt2.target.run('hciconfig hci0 noscan')
+            # begin low-energy scan
+            self.bt2.target.run('hciconfig hci0 leadv')
+            time.sleep(1)
+            # Device starts bluetoothctl to scan others 
+            exp = os.path.join(os.path.dirname(__file__), "files/bt_scan.exp")
+            cmd = "expect %s %s %s" % (exp, self.bt1.target.ip, self.bt2.get_bt_mac())
+            status, output = shell_cmd_timeout(cmd, timeout=100)
+            if status == 2:
+                break
+            else:
+                self.bt2.target.run('hciconfig hci0 reset')
+                time.sleep(3)
         self.assertEqual(status, 2, msg="LE Scan other fails: %s" % output) 
 
     @tag(FeatureID="IOTOS-453")
@@ -258,7 +275,10 @@ class CommBTTestMNode(oeRuntimeTest):
         # On target, perform pair_master
         master_exp = os.path.join(os.path.dirname(__file__), "files/bt_pair_master.exp")
         cmd = "expect %s %s %s" % (master_exp, self.bt1.target.ip, self.bt2.get_bt_mac())
-        (status, output) = shell_cmd_timeout(cmd, timeout=200)
+        for i in range(3):
+            (status, output) = shell_cmd_timeout(cmd, timeout=200)
+            if status == 2:
+                break
         self.assertEqual(status, 2, msg="expect excution fail: %s" % output)
 
         # On target, check paired devices to see if IoT is in

--- a/lib/oeqa/runtime/ethernet/comm_ethernet.py
+++ b/lib/oeqa/runtime/ethernet/comm_ethernet.py
@@ -61,9 +61,13 @@ class CommEthernet(oeRuntimeTest):
         @param self
         @return
         """
-        # Get target ip address prefix of LAN, for example, 192.168.8.100 is 192.168.8
-        ipv4 = self.get_ipv4().split('.')
-        prefix = "%s.%s.%s" % (ipv4[0], ipv4[1], ipv4[2])
+        # if user takes -s option, it is host's IP, directly use it
+        if '192.168.7.1' == self.target.server_ip:
+            # Get target ip address prefix of LAN, for example, 192.168.8.100 is 192.168.8
+            ipv4 = self.get_ipv4().split('.')
+            prefix = "%s.%s.%s" % (ipv4[0], ipv4[1], ipv4[2])
+        else:
+            prefix = self.target.server_ip
         # Use this prefix to get corresponding interface of the host
         (status, ifconfig) = shell_cmd_timeout('ifconfig')
         for line in ifconfig.splitlines():
@@ -72,7 +76,7 @@ class CommEthernet(oeRuntimeTest):
                 return ifconfig.splitlines()[index - 1].split()[0]
 
         # if above return is not OK, there might be error, return Blank
-        self.assertEqual(1, 0, msg="Target with address %s is not connectable" % ipv4)
+        self.assertEqual(1, 0, msg="Host interface with %s is not found" % prefix)
 
     @tag(FeatureID="IOTOS-489")
     def test_ethernet_ipv6_ping(self):

--- a/lib/oeqa/runtime/iotivity/files/group_client.exp
+++ b/lib/oeqa/runtime/iotivity/files/group_client.exp
@@ -1,5 +1,5 @@
 #!/usr/bin/expect
-set timeout 10
+set timeout 30
 set ip      [lindex $argv 0] 
 spawn ssh root@$ip -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR /opt/iotivity/examples/resource/cpp/groupclient
  expect {

--- a/lib/oeqa/runtime/iotivity/iotvt_integration.py
+++ b/lib/oeqa/runtime/iotivity/iotvt_integration.py
@@ -39,6 +39,12 @@ class IOtvtIntegration(oeRuntimeTest):
         cls.tc.target.run("killall simpleclientserver threadingsample")
         cls.tc.target.run("rm -f /tmp/svr_output")
         cls.tc.target.run("rm -f /tmp/output")
+        # check if image contains iotivity example applications
+        (status, output) = cls.tc.target.run("ls /opt/iotivity/examples/resource/")
+        if "cpp" in output:
+            pass
+        else:
+            assert 1 == 0, 'There is no iotivity exmaple app installed'
         # add group and non-root user
         add_group("tester")
         add_user("iotivity-tester", "tester")

--- a/lib/oeqa/runtime/iotivity/iotvt_integration_mnode.py
+++ b/lib/oeqa/runtime/iotivity/iotvt_integration_mnode.py
@@ -56,6 +56,17 @@ class IOtvtIntegrationMNode(oeRuntimeTest):
         run_as("root", "/usr/sbin/iptables -w -A INPUT -p udp --dport 5684 -j ACCEPT", target=cls.tc.targets[0])
         run_as("root", "/usr/sbin/iptables -w -A INPUT -p udp --dport 5683 -j ACCEPT", target=cls.tc.targets[1])
         run_as("root", "/usr/sbin/iptables -w -A INPUT -p udp --dport 5684 -j ACCEPT", target=cls.tc.targets[1])
+        # check if image contains iotivity example applications
+        (status, output) = run_as("root", "ls /opt/iotivity/examples/resource/", target=cls.tc.targets[0])
+        if "cpp" in output:
+            pass
+        else:
+            assert 1 == 0, 'There is no iotivity exmaple app installed in target0'
+        (status, output) = run_as("root", "ls /opt/iotivity/examples/resource/", target=cls.tc.targets[1])
+        if "cpp" in output:
+            pass
+        else:
+            assert 1 == 0, 'There is no iotivity exmaple app installed in target1'
 
     @classmethod
     def tearDownClass(cls):
@@ -185,7 +196,7 @@ class IOtvtIntegrationMNode(oeRuntimeTest):
         '''
         # start light server and group server
         lightserver_cmd = "/opt/iotivity/examples/resource/cpp/lightserver > /tmp/svr_output &"
-        (status, output) = self.target.run(lightserver_cmd, target=self.targets[1])
+        (status, output) = run_as("root", lightserver_cmd, target=self.targets[1])
         time.sleep(2)
         ssh_cmd = "ssh root@%s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR" % self.targets[1].ip
         groupserver_cmd = "/opt/iotivity/examples/resource/cpp/groupserver > /dev/null 2>&1"

--- a/lib/oeqa/runtime/iotivity/iotvt_wifi.py
+++ b/lib/oeqa/runtime/iotivity/iotvt_wifi.py
@@ -72,6 +72,18 @@ class IOtvtWiFi(oeRuntimeTest):
         run_as("root", "/usr/sbin/iptables -w -A INPUT -p udp --dport 5683 -j ACCEPT", target=cls.tc.targets[1])
         run_as("root", "/usr/sbin/iptables -w -A INPUT -p udp --dport 5684 -j ACCEPT", target=cls.tc.targets[1])
 
+        # check if image contains iotivity example applications
+        (status, output) = run_as("root", "ls /opt/iotivity/examples/resource/", target=cls.tc.targets[0])
+        if "cpp" in output:
+            pass
+        else:
+            assert 1 == 0, 'There is no iotivity exmaple app installed in target0'
+        (status, output) = run_as("root", "ls /opt/iotivity/examples/resource/", target=cls.tc.targets[1])
+        if "cpp" in output:
+            pass
+        else:
+            assert 1 == 0, 'There is no iotivity exmaple app installed in target1'
+
         for i in range(3):
             # Do simpleclient test
             server_cmd = "/opt/iotivity/examples/resource/cpp/simpleserver > /tmp/srv_output &"

--- a/lib/oeqa/runtime/wifi/comm_wifi_connect.py
+++ b/lib/oeqa/runtime/wifi/comm_wifi_connect.py
@@ -134,9 +134,10 @@ class CommWiFiConect(oeRuntimeTest):
         ap_type = "broadcast"
         ssid = ssid_config.get("Connect","ssid_broadcast")
         pwd = ssid_config.get("Connect","passwd_broadcast")
+        url = ssid_config.get("Internet","url")
 
         self.wifi.execute_connection(ap_type, ssid, pwd)
-        self.wifi.check_internet_connection()
+        self.wifi.check_internet_connection(url)
 
     @tag(FeatureID="IOTOS-458")
     def test_connect_wep(self):

--- a/lib/oeqa/runtime/wifi/comm_wifi_mnode.py
+++ b/lib/oeqa/runtime/wifi/comm_wifi_mnode.py
@@ -106,7 +106,7 @@ class CommWiFiMNode(oeRuntimeTest):
         @return
         '''
         # clean files on both sides
-        self.wifi2.target.run('rm -f /tmp/*')
+        self.wifi2.target.run('rm -f /home/root/*')
         self.wifi1.ipv4_ssh_to(self.wifi2.get_wifi_ipv4())
         # create 1000 files under /tmp/1000/ on target1
         script = os.path.join(os.path.dirname(__file__), "files/create_1000_files.sh")
@@ -114,12 +114,12 @@ class CommWiFiMNode(oeRuntimeTest):
         self.wifi1.target.run('sh /tmp/create_1000_files.sh')
 
         # scp them to target2 /tmp/ folder
-        (status, file_number_old) = self.wifi2.target.run('ls /tmp/ | wc -l')
+        (status, file_number_old) = self.wifi2.target.run('ls /home/root/ | wc -l')
         file_path = '/tmp/1000/*'
         self.wifi1.scp_to(file_path, self.wifi2.get_wifi_ipv4())
 
         # check if /tmp/ files number increase 1000 on target2
-        (status, file_number_new) = self.wifi2.target.run('ls /tmp/ | wc -l')
+        (status, file_number_new) = self.wifi2.target.run('ls /home/root/ | wc -l')
         if int(file_number_new) - int(file_number_old) == 1000:
             pass
         else:
@@ -135,15 +135,16 @@ class CommWiFiMNode(oeRuntimeTest):
         self.wifi1.ipv4_ssh_to(self.wifi2.get_wifi_ipv4())
         file_path = '/home/root/big_file'
         # create a big file, size is 500M
-        (status, patition) = self.wifi1.target.run('df | grep " /$"')
+        (status, patition) = self.wifi1.target.run('mount | grep " \/ "')
         self.wifi1.target.run('dd if=%s of=%s bs=1M count=500' % (patition.split()[0], file_path))
 
-        # scp it to target2 /tmp/ folder
+        # scp it to target2 /home/root/ folder
+        self.wifi2.target.run('rm -f /home/root/*')
         self.wifi1.scp_to(file_path, self.wifi2.get_wifi_ipv4())
 
         # check if md5sume is consistent
         (status, md5sum1) = self.wifi1.target.run('md5sum %s' % file_path)
-        (status, md5sum2) = self.wifi2.target.run('md5sum /tmp/%s' % file_path.split('/')[-1])
+        (status, md5sum2) = self.wifi2.target.run('md5sum /home/root/%s' % file_path.split('/')[-1])
         if md5sum1.split()[0] == md5sum2.split()[0]:
             pass
         else:

--- a/lib/oeqa/runtime/wifi/files/config.ini
+++ b/lib/oeqa/runtime/wifi/files/config.ini
@@ -11,3 +11,5 @@ ssid_80211n=shz13-otc-bsp-tests
 passwd_80211n=iotqatest
 ssid_broadcast=shz14f-ssg-otc-qa-xwalk
 passwd_broadcast=xwalk1234
+[Internet]
+url=http://www.baidu.com


### PR DESCRIPTION
Add more trial for comms domain:
Enlarge iotivity/groupclient working time from 10s to 30s.
Add file existance check for iotivity/roomclient.
Add -s option support in Ethernet case to get Host interface.
Modify WiFi/big_file creation to be under /home/root folder.
Enable WiFi/internet url to be configured in config.ini.
Enable 3 trial from services scan when WiFi connection failure.
Enable 3 trial for Bluetooth 6lowpan if bt0 is not initialized.
Enable 3 trial for BT BLE scan if it fails.

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>