### PR TITLE
zigbee: add module remove functions for both atmel and cc2520

### DIFF
--- a/lib/oeqa/runtime/zigbee/comm_zigbee_basic.py
+++ b/lib/oeqa/runtime/zigbee/comm_zigbee_basic.py
@@ -32,6 +32,14 @@ class ZigBeeBasic(oeRuntimeTest):
         '''
         self.zigbee = zigbee.ZigBeeFunction(self.target)
 
+    def tearDown(self):
+        ''' initialize zigbee class
+        @fn setUp
+        @param self
+        @return
+        '''
+        self.zigbee.remove_atmel_mode()
+
     @tag(FeatureID="IOTOS-1220")
     def test_insert_atmel_module(self):
         '''Insert atmel module to enable 802.15.4
@@ -39,6 +47,7 @@ class ZigBeeBasic(oeRuntimeTest):
         @param self
         @return
         '''
+        self.zigbee.remove_cc2520_mode()
         self.zigbee.insert_atmel_mode()
 
 ##

--- a/lib/oeqa/runtime/zigbee/comm_zigbee_cc2520.py
+++ b/lib/oeqa/runtime/zigbee/comm_zigbee_cc2520.py
@@ -32,6 +32,14 @@ class ZigBeeCC2520(oeRuntimeTest):
         '''
         self.zigbee = zigbee.ZigBeeFunction(self.target)
 
+    def tearDown(self):
+        ''' teardown cc2520 class 
+        @fn setUp
+        @param self
+        @return
+        '''
+        self.zigbee.remove_cc2520_mode()
+
     @tag(FeatureID="IOTOS-763")
     def test_insert_cc2520_module(self):
         '''Insert cc2520 module
@@ -39,6 +47,7 @@ class ZigBeeCC2520(oeRuntimeTest):
         @param self
         @return
         '''
+        self.zigbee.remove_atmel_mode()
         self.zigbee.insert_cc2520_mode()
 
 ##

--- a/lib/oeqa/runtime/zigbee/comm_zigbee_mnode.py
+++ b/lib/oeqa/runtime/zigbee/comm_zigbee_mnode.py
@@ -33,8 +33,10 @@ class ZigBeeMNode(oeRuntimeTest):
         '''
         self.zigbee1 = zigbee.ZigBeeFunction(self.targets[0])
         self.zigbee1.clean_up()
+        self.zigbee1.remove_cc2520_mode()        
         self.zigbee2 = zigbee.ZigBeeFunction(self.targets[1])
         self.zigbee2.clean_up()
+        self.zigbee2.remove_cc2520_mode()        
 
     def tearDown(self):
         ''' tearDown zigbee case
@@ -44,6 +46,8 @@ class ZigBeeMNode(oeRuntimeTest):
         '''
         self.zigbee1.clean_up()
         self.zigbee2.clean_up()
+        self.zigbee1.remove_atmel_mode()
+        self.zigbee2.remove_atmel_mode()
 
     @tag(FeatureID="IOTOS-1220")
     def test_zigbee_atmel_ping6_out(self):

--- a/lib/oeqa/runtime/zigbee/zigbee.py
+++ b/lib/oeqa/runtime/zigbee/zigbee.py
@@ -75,6 +75,24 @@ class ZigBeeFunction(object):
         else:
             assert False, "Not initialize 802.15.4 module. see dmesg log:\n%s" % output 
 
+    def remove_atmel_mode(self):
+        ''' Remove atmel modules
+        @fn remove_atmel_mode
+        @param self
+        @return
+        '''
+        if self.platform == "Galileo":
+            self.target.run('rmmod at86rf230')
+            self.target.run('rmmod spi_quark_board')
+            self.target.run('rmmod spi_quark_at86rf230')
+        elif self.platform == "MinnowMax":
+            self.target.run('rmmod spi_minnow_board')
+            self.target.run('rmmod spi_minnow_at86rf230')           
+
+        (status, output) = self.target.run('lsmod')
+        if "spi_quark_at" in output or "spi_minnow_at" in output:
+            assert False, "Fail to remove atmel modules:\n%s" % output
+
     def insert_cc2520_mode(self):
         ''' Insert cc2520 modules 
         @fn insert_cc2520_mode
@@ -85,10 +103,22 @@ class ZigBeeFunction(object):
         assert status == 0, "Error messages: %s" % output 
         # Check dmesg log, to see if the 802.15.4 is registered
         (status, output) = self.target.run('lsmod')
-        if self.cc2520_mod_name in output:
+        if "spi_minnow_cc2520" in output:
             pass
         else:
             assert False, "Not initialize cc2520 module. see lsmod:\n%s" % output
+
+    def remove_cc2520_mode(self):
+        ''' Remove cc2520 modules
+        @fn remove_cc2520_mode
+        @param self
+        @return
+        '''
+        self.target.run('rmmod spi_minnow_cc2520')
+
+        (status, output) = self.target.run('lsmod')
+        if "cc2520" in output:
+            assert False, "Fail to remove cc2520 modules:\n%s" % output
 
     def atmel_enable_lowpan0(self, ip_number):
         ''' enable atmel chipset on target 


### PR DESCRIPTION
To fix IOTOS-1540, add zigbee module removement functions. When
runninf atmel cases it will remove cc2520 module and after case
done it also removes atmel modules. Same to the opposite.

[skip-ci]

Signed-off-by: Zhang Jingke <jingke.zhang@intel.com>