### PR TITLE
soletta.manifest: remove soletta-dev-app test plan

### DIFF
--- a/conf/test/soletta.manifest
+++ b/conf/test/soletta.manifest
@@ -1,3 +1,2 @@
 oeqa.runtime.soletta.soletta
-oeqa.runtime.soletta.soletta_dev_app
 oeqa.runtime.soletta.soletta_auto


### PR DESCRIPTION
Considering Soletta-dev-app build error will be fixed
in Ostro 1.3 (IOTOS-1543). Remove relative cases in
current test execution plan.

[skip-ci]

Signed-off-by: Lei Yang <lei.a.yang@intel.com>