### PR TITLE
test-iot.bbclass: Python3 compatibility

### DIFF
--- a/classes/test-iot.bbclass
+++ b/classes/test-iot.bbclass
@@ -108,7 +108,7 @@ def recursive_overwrite(src, dest, notOverWrite=[r'__init__\.py'], ignores=[r".+
     else:
         try:
             shutil.copy2(src, dest)
-        except IOError, e :
+        except IOError as e:
             bb.warn(str(e))
    
 #export test asset


### PR DESCRIPTION
"except Foo, ex" is no longer supported in Python3. "except Foo as ex" works
in both Python2 and Python3.

Merging this is urgent. It will block automatic upstream updates (see
https://github.com/ostroproject/ostro-os/pull/116).