### PR TITLE
Update restapi test scripts for enable restapi server before run tests

### DIFF
--- a/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_d.js
+++ b/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_d.js
@@ -1,5 +1,6 @@
 var http = require('http');
 var fs = require('fs');
+var path = require('path');
 
 var options = {
     host: '127.0.0.1',
@@ -12,7 +13,7 @@ var options = {
 };
 
 var apiOicD = {};
-var responseJson = 'api_oic_d.json';
+var responseJson = path.join(path.dirname(__filename), 'api_oic_d.json');
 
 function sendHttpRequest(opts) {
     var req = http.request(opts, function(res) {

--- a/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_p.js
+++ b/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_p.js
@@ -1,5 +1,6 @@
 var http = require('http');
 var fs = require('fs');
+var path = require('path');
 
 var options = {
     host: '127.0.0.1',

--- a/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_res.js
+++ b/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_res.js
@@ -1,5 +1,6 @@
 var http = require('http');
 var fs = require('fs');
+var path = require('path');
 
 var options = {
     host: '127.0.0.1',
@@ -12,7 +13,7 @@ var options = {
 };
 
 var apiOicRes = {};
-var responseJson = 'api_oic_res.json';
+var responseJson = path.join(path.dirname(__filename), 'api_oic_res.json');
 
 function sendHttpRequest(opts) {
     var req = http.request(opts, function(res) {    

--- a/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_system.js
+++ b/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_system.js
@@ -1,6 +1,7 @@
 var http = require('http');
 var fs = require('fs');
 var os = require('os');
+var path = require('path');
 
 var options = {
     host: '127.0.0.1',
@@ -13,7 +14,7 @@ var options = {
 };
 
 var apiSystem = {};
-var responseJson = 'api_system.json';
+var responseJson = path.join(path.dirname(__filename), 'api_system.json');
 
 function sendHttpRequest(opts) {
     var req = http.request(opts, function(res) {    


### PR DESCRIPTION
- Check the server whether start before issue the request
- Stop the server after run test over
- Add node module path for js coverage script

Signed-off-by: Wang Hongjuan <hongjuan.wang@intel.com>