### PR TITLE
update bluetooth and wifi TCs for python3

### DIFF
--- a/lib/oeqa/runtime/bluetooth/comm_bt_6lowpan.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_6lowpan.py
@@ -13,7 +13,7 @@
 
 import os
 import time
-import bluetooth
+from oeqa.runtime.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.decorators import tag

--- a/lib/oeqa/runtime/bluetooth/comm_bt_6lowpan_mnode.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_6lowpan_mnode.py
@@ -13,7 +13,7 @@
 
 import os
 import time
-import bluetooth
+from oeqa.runtime.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.decorators import tag
@@ -101,4 +101,3 @@ class CommBT6LowPanMNode(oeRuntimeTest):
 # @}
 # @}
 ##
-

--- a/lib/oeqa/runtime/bluetooth/comm_bt_command.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_command.py
@@ -14,7 +14,7 @@
 import os
 import time
 import subprocess
-import bluetooth
+from oeqa.runtime.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.helper import get_files_dir

--- a/lib/oeqa/runtime/bluetooth/comm_bt_command_mnode.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_command_mnode.py
@@ -14,7 +14,7 @@
 import os
 import time
 import subprocess
-import bluetooth
+from oeqa.runtime.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.helper import get_files_dir

--- a/lib/oeqa/runtime/bluetooth/comm_bt_stability.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_stability.py
@@ -14,7 +14,7 @@
 import os
 import time
 import subprocess
-import bluetooth
+from oeqa.runtime.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.helper import get_files_dir
@@ -45,7 +45,7 @@ class BTStabilityTest(oeRuntimeTest):
             self.bt.ctl_power_on()
             self.bt.ctl_power_off()
             if i % 20 == 0:
-                print "Finish %d times, successful." % i
+                print ("Finish %d times, successful." % i)
 
     @tag(FeatureID="IOTOS-453")
     def test_bt_visable_onoff_multiple_time(self):
@@ -60,7 +60,7 @@ class BTStabilityTest(oeRuntimeTest):
             self.bt.ctl_visable_on()
             self.bt.ctl_visable_off()
             if i % 20 == 0:
-                print "Finish %d times, successful." % i
+                print ("Finish %d times, successful." % i)
 
 ##
 # @}

--- a/lib/oeqa/runtime/sanity/comm_wifi_connect.py
+++ b/lib/oeqa/runtime/sanity/comm_wifi_connect.py
@@ -15,7 +15,10 @@ import time
 import os
 from oeqa.runtime.wifi import wifi
 import string
-import ConfigParser
+try:
+ import ConfigParser
+except:
+ import configparser as ConfigParser
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.decorators import tag


### PR DESCRIPTION
To adopt python3 execution, update corresponding BT and wifi TCs.
[skip-ci]