### PR TITLE
update comms TCs to give correct format of error logs for python3

### DIFF
--- a/lib/oeqa/runtime/bluetooth/bluetooth.py
+++ b/lib/oeqa/runtime/bluetooth/bluetooth.py
@@ -93,7 +93,7 @@ class BTFunction(object):
         btmac = self.get_bt_mac()
         cmd = 'expect %s %s %s' % (exp, self.target.ip, btmac)
         (status, output) = shell_cmd_timeout(cmd)
-        assert status == 0, "Get hci0 name fails: %s" % output
+        assert status == 0, "Get hci0 name fails: %s" % output.decode("ascii")
         for line in output.splitlines():
             if "Controller %s" % btmac in line.decode('ascii'):
                 return line.split()[3]
@@ -131,7 +131,7 @@ class BTFunction(object):
         exp = os.path.join(os.path.dirname(__file__), "files/power_on.exp")
         target_ip = self.target.ip
         status, output = shell_cmd_timeout('expect %s %s' % (exp, target_ip), timeout=200)
-        assert status == 2, "power on command fails: %s" % output
+        assert status == 2, "power on command fails: %s" % output.decode("ascii")
 
     def ctl_power_off(self):
         '''bluetoothctl power off bluetooth device
@@ -143,7 +143,7 @@ class BTFunction(object):
         exp = os.path.join(os.path.dirname(__file__), "files/power_off.exp")
         target_ip = self.target.ip
         status, output = shell_cmd_timeout('expect %s %s' % (exp, target_ip), timeout=200)
-        assert status == 2, "power off command fails: %s" % output
+        assert status == 2, "power off command fails: %s" % output.decode("ascii")
 
     def ctl_visable_on(self):
         '''bluetoothctl enable visibility
@@ -155,7 +155,7 @@ class BTFunction(object):
         exp = os.path.join(os.path.dirname(__file__), "files/discoverable_on.exp")
         target_ip = self.target.ip
         status, output = shell_cmd_timeout('expect %s %s' % (exp, target_ip), timeout=200)
-        assert status == 2, "discoverable on command fails: %s" % output
+        assert status == 2, "discoverable on command fails: %s" % output.decode("ascii")
 
     def ctl_visable_off(self):
         '''bluetoothctl disable visibility
@@ -167,7 +167,7 @@ class BTFunction(object):
         exp = os.path.join(os.path.dirname(__file__), "files/discoverable_off.exp")
         target_ip = self.target.ip
         status, output = shell_cmd_timeout('expect %s %s' % (exp, target_ip), timeout=200)
-        assert status == 2, "discoverable off command fails: %s" % output
+        assert status == 2, "discoverable off command fails: %s" % output.decode("ascii")
 
     def insert_6lowpan_module(self):
         '''Insert BLE 6lowpan module
@@ -244,7 +244,7 @@ class BTFunction(object):
         exp = os.path.join(os.path.dirname(__file__), "files/target_ssh.exp")
         exp_cmd = 'expect %s %s %s' % (exp, self.target.ip, ipv6)
         (status, output) = shell_cmd_timeout(exp_cmd)
-        assert status == 2, "Error messages: %s" % output
+        assert status == 2, "Error messages: %s" % output.decode("ascii")
 
     def connect_6lowpan_ble(self, second):
         '''Build 6lowpan connection between taregts[0] and targets[1] over BLE

--- a/lib/oeqa/runtime/bluetooth/comm_bt_command_mnode.py
+++ b/lib/oeqa/runtime/bluetooth/comm_bt_command_mnode.py
@@ -193,7 +193,7 @@ class CommBTTestMNode(oeRuntimeTest):
             status, output = shell_cmd_timeout(cmd, timeout=100)
             if status == 2:
                 break
-        self.assertEqual(status, 2, msg="Scan remote device fails: %s" % output) 
+        self.assertEqual(status, 2, msg="Scan remote device fails: %s" % output.decode("ascii")) 
 
     @tag(FeatureID="IOTOS-456")
     def test_bt_scan(self):
@@ -210,7 +210,7 @@ class CommBTTestMNode(oeRuntimeTest):
             status, output = shell_cmd_timeout(cmd, timeout=100)
             if status == 2:
                 break
-        self.assertEqual(status, 2, msg="Scan remote device fails: %s" % output) 
+        self.assertEqual(status, 2, msg="Scan remote device fails: %s" % output.decode("ascii")) 
 
     @tag(FeatureID="IOTOS-759")
     def test_bt_le_advertising(self):
@@ -234,7 +234,7 @@ class CommBTTestMNode(oeRuntimeTest):
             else:
                 self.bt1.target.run('hciconfig hci0 reset')
                 time.sleep(3)
-        self.assertEqual(status, 2, msg="Be LE-scanned fails: %s" % output) 
+        self.assertEqual(status, 2, msg="Be LE-scanned fails: %s" % output.decode("ascii")) 
 
     @tag(FeatureID="IOTOS-770")
     def test_bt_le_scan(self):
@@ -258,7 +258,7 @@ class CommBTTestMNode(oeRuntimeTest):
             else:
                 self.bt2.target.run('hciconfig hci0 reset')
                 time.sleep(3)
-        self.assertEqual(status, 2, msg="LE Scan other fails: %s" % output) 
+        self.assertEqual(status, 2, msg="LE Scan other fails: %s" % output.decode("ascii")) 
 
     @tag(FeatureID="IOTOS-453")
     def test_bt_pairing(self):
@@ -279,7 +279,7 @@ class CommBTTestMNode(oeRuntimeTest):
             (status, output) = shell_cmd_timeout(cmd, timeout=200)
             if status == 2:
                 break
-        self.assertEqual(status, 2, msg="expect excution fail: %s" % output)
+        self.assertEqual(status, 2, msg="expect excution fail: %s" % output.decode("ascii"))
 
         # On target, check paired devices to see if IoT is in
         check_exp = os.path.join(os.path.dirname(__file__), "files/bt_list_paired_device.exp")

--- a/lib/oeqa/runtime/ethernet/comm_ethernet.py
+++ b/lib/oeqa/runtime/ethernet/comm_ethernet.py
@@ -90,12 +90,12 @@ class CommEthernet(oeRuntimeTest):
         # ping6 needs host's ethernet interface by -I, 
         # because default gateway is only for ipv4
         host_eth = self.get_interface()
-        cmd = "ping6 -I %s %s -c 1" % (host_eth, ip6_address) 
+        cmd = "ping6 -I %s %s -c 1" % (host_eth.decode("ascii"), ip6_address) 
         status, output = shell_cmd_timeout(cmd, timeout=60)
         ##
         # TESTPOINT: #1, test_ethernet_ipv6_ping
         #
-        self.assertEqual(status, 0, msg="Error messages: %s" % output)
+        self.assertEqual(status, 0, msg="Error messages: %s" % output.decode("ascii"))
 
     @tag(FeatureID="IOTOS-489")
     def test_ethernet_ipv6_ssh(self):
@@ -111,14 +111,14 @@ class CommEthernet(oeRuntimeTest):
         host_eth = self.get_interface()
 
         exp = os.path.join(os.path.dirname(__file__), "files/ipv6_ssh.exp")
-        cmd = "expect %s %s %s %s" % (exp, ip6_address, "ostro", host_eth)
+        cmd = "expect %s %s %s %s" % (exp, ip6_address, "ostro", host_eth.decode("ascii"))
         status, output = shell_cmd_timeout(cmd, timeout=60)
         # In expect, it will input yes and password while login. And do 'ls /'
         # If see /home folder, it will return 2 as successful status.
         ##
         # TESTPOINT: #1, test_ethernet_ipv6_ssh
         #
-        self.assertEqual(status, 2, msg="Error messages: %s" % output)
+        self.assertEqual(status, 2, msg="Error messages: %s" % output.decode("ascii"))
 
 ##
 # @}

--- a/lib/oeqa/runtime/iotivity/iotvt_integration.py
+++ b/lib/oeqa/runtime/iotivity/iotvt_integration.py
@@ -228,7 +228,7 @@ class IOtvtIntegration(oeRuntimeTest):
         ##
         # TESTPOINT: #1, test_group
         #
-        self.assertEqual(status, 2, msg="expect excution fail\n %s" % output)
+        self.assertEqual(status, 2, msg="expect excution fail\n %s" % output.decode("ascii"))
 
     def test_presence_unicast(self):
         '''

--- a/lib/oeqa/runtime/iotivity/iotvt_integration_mnode.py
+++ b/lib/oeqa/runtime/iotivity/iotvt_integration_mnode.py
@@ -213,7 +213,7 @@ class IOtvtIntegrationMNode(oeRuntimeTest):
         ##
         # TESTPOINT: #1, test_group
         #
-        self.assertEqual(status, 2, msg="expect excution fail\n %s" % output)
+        self.assertEqual(status, 2, msg="expect excution fail\n %s" % output.decode("ascii"))
 
     def test_mnode_presence_unicast(self):
         '''

--- a/lib/oeqa/runtime/wifi/wifi.py
+++ b/lib/oeqa/runtime/wifi/wifi.py
@@ -89,7 +89,7 @@ class WiFiFunction(object):
         if "hidden" in ap_type:
             return output.strip()
         elif (ap_type == "broadcast"):
-            return output.split(" ")[-1]
+            return output.split("\n")[0].split(" ")[-1]
 
     def connect_wifi(self, ap_type, ssid, pwd):
         '''connmanctl to connect wifi AP
@@ -113,7 +113,7 @@ class WiFiFunction(object):
             status, output = shell_cmd_timeout(cmd, timeout=60)
             if status == 2:
                 break        
-        assert status == 2, "Error messages: %s" % output 
+        assert status == 2, "Error messages: %s" % output.decode("ascii") 
 
     def get_wifi_ipv4(self):
         ''' Get wifi ipv4 address
@@ -211,7 +211,7 @@ class WiFiFunction(object):
         exp = os.path.join(os.path.dirname(__file__), "files/ssh_to.exp")
         exp_cmd = 'expect %s %s %s' % (exp, self.target.ip, ipv4)
         (status, output) = shell_cmd_timeout(exp_cmd)
-        assert status == 2, "Error messages: %s" % output
+        assert status == 2, "Error messages: %s" % output.decode("ascii")
 
     def scp_to(self, file_path, ipv4):
         ''' On main target, scp file to second


### PR DESCRIPTION
1. update error output to string from bytes
2. fix wifi TC to handle when multi services match single ssid

[skip-ci]

Signed-off-by: yma11 <yan.ma@intel.com>