### PR TITLE
iotivity: open holes to IPv6 firewall.

### DIFF
--- a/lib/oeqa/runtime/iotivity/iotvt_integration.py
+++ b/lib/oeqa/runtime/iotivity/iotvt_integration.py
@@ -49,8 +49,13 @@ class IOtvtIntegration(oeRuntimeTest):
         add_group("tester")
         add_user("iotivity-tester", "tester")
         # Setup firewall accept for multicast
+        (status, output) = cls.tc.target.run("cat /proc/sys/net/ipv4/ip_local_port_range")
+        port_range = output.split()
         cls.tc.target.run("/usr/sbin/iptables -w -A INPUT -p udp --dport 5683 -j ACCEPT")
         cls.tc.target.run("/usr/sbin/iptables -w -A INPUT -p udp --dport 5684 -j ACCEPT")
+        cls.tc.target.run("/usr/sbin/ip6tables -w -A INPUT -s fe80::/10 -p udp -m udp --dport 5683 -j ACCEPT")
+        cls.tc.target.run("/usr/sbin/ip6tables -w -A INPUT -s fe80::/10 -p udp -m udp --dport 5684 -j ACCEPT")
+        cls.tc.target.run("/usr/sbin/ip6tables -w -A INPUT -s fe80::/10 -p udp -m udp --dport %s:%s -j ACCEPT" % (port_range[0], port_range[1]))
 
     @classmethod
     def tearDownClass(cls):

--- a/lib/oeqa/runtime/sanity/iotivity.py
+++ b/lib/oeqa/runtime/sanity/iotivity.py
@@ -37,6 +37,14 @@ class IOtvtClient(oeRuntimeTest):
         add_group("tester")
         add_user("iotivity-tester", "tester")
 
+        # set up firewall
+        (status, output) = cls.tc.target.run("cat /proc/sys/net/ipv4/ip_local_port_range")
+        port_range = output.split()
+
+        cls.tc.target.run("/usr/sbin/ip6tables -w -A INPUT -s fe80::/10 -p udp -m udp --dport 5683 -j ACCEPT")
+        cls.tc.target.run("/usr/sbin/ip6tables -w -A INPUT -s fe80::/10 -p udp -m udp --dport 5684 -j ACCEPT")
+        cls.tc.target.run("/usr/sbin/ip6tables -w -A INPUT -s fe80::/10 -p udp -m udp --dport %s:%s -j ACCEPT" % (port_range[0], port_range[1]))
+
         # start server
         server_cmd = "/opt/iotivity/examples/resource/cpp/simpleserver > /tmp/svr_output &"
         run_as("iotivity-tester", server_cmd)


### PR DESCRIPTION
We are tightening overall ip6tables firewall settings. Make holes to the firewall so that the Iotivity tests can succeed. Since Iotivity opens a random unicast listening port, we need to open all "ephemeral" ports for link-local access. After this PR is merged https://github.com/ostroproject/meta-ostro/pull/249 can pass the tests.