### PR TITLE
recipes-test: fix "ldflags" package QA test for test utils

### DIFF
--- a/recipes-test/hello-bundle-a/hello-bundle-a.bb
+++ b/recipes-test/hello-bundle-a/hello-bundle-a.bb
@@ -8,8 +8,8 @@ SRC_URI = "file://hello-bundle-a.c \
 
 S = "${WORKDIR}"
 do_compile() {
-    ${CC} hello-bundle-a.c -o hello-bundle-a
-    ${CC} hello-bundle-c.c -o hello-bundle-c
+    ${CC} hello-bundle-a.c ${LDFLAGS} -o hello-bundle-a
+    ${CC} hello-bundle-c.c ${LDFLAGS} -o hello-bundle-c
 }
  
 do_install() {

--- a/recipes-test/hello-bundle-b/hello-bundle-b.bb
+++ b/recipes-test/hello-bundle-b/hello-bundle-b.bb
@@ -7,7 +7,7 @@ SRC_URI = "file://hello-bundle-b.c \
 
 S = "${WORKDIR}"
 do_compile() {
-    ${CC} hello-bundle-b.c -o hello-bundle-b
+    ${CC} hello-bundle-b.c ${LDFLAGS} -o hello-bundle-b
 }
  
 do_install() {

--- a/recipes-test/hello-bundle-s/hello-bundle-s.bb
+++ b/recipes-test/hello-bundle-s/hello-bundle-s.bb
@@ -7,7 +7,7 @@ SRC_URI = "file://hello-bundle-s.c \
 
 S = "${WORKDIR}"
 do_compile() {
-    ${CC} hello-bundle-s.c -o hello-bundle-s
+    ${CC} hello-bundle-s.c ${LDFLAGS} -o hello-bundle-s
 }
  
 do_install() {

--- a/recipes-test/hello/hello.bb
+++ b/recipes-test/hello/hello.bb
@@ -7,7 +7,7 @@ SRC_URI = "file://hello.c \
 
 S = "${WORKDIR}"
 do_compile() {
-    ${CC} hello.c -o hello
+    ${CC} hello.c ${LDFLAGS} -o hello
 }
  
 do_install() {

--- a/recipes-test/mraa-test/mraa-test_1.0.0.bb
+++ b/recipes-test/mraa-test/mraa-test_1.0.0.bb
@@ -9,7 +9,7 @@ SRC_URI = "file://hello_mraa.c \
 S = "${WORKDIR}"
 
 do_compile() {
-    ${CC} hello_mraa.c -o hello_mraa -lmraa
+    ${CC} hello_mraa.c ${LDFLAGS} -o hello_mraa -lmraa
 }
 
 do_install() {

--- a/recipes-test/openmp-app/openmp-app.bb
+++ b/recipes-test/openmp-app/openmp-app.bb
@@ -10,7 +10,7 @@ do_configure() {
 }
 
 do_compile() {
-	${CC} ${CFLAGS} -fopenmp -o ${WORKDIR}/openmp-app ${S}/openmp-app.c
+	${CC} ${CFLAGS} -fopenmp ${LDFLAGS} -o ${WORKDIR}/openmp-app ${S}/openmp-app.c
 }
 
 do_install() {

--- a/recipes-test/read-map/read-map_1.0.0.0.bb
+++ b/recipes-test/read-map/read-map_1.0.0.0.bb
@@ -8,7 +8,7 @@ SRC_URI = "file://read-map.c \
 S = "${WORKDIR}"
 
 do_compile() {
-    ${CC} read-map.c -o read-map
+    ${CC} read-map.c ${LDFLAGS} -o read-map
 }
 
 do_install() {

--- a/recipes-test/shm-util/shm-util_1.0.0.0.bb
+++ b/recipes-test/shm-util/shm-util_1.0.0.0.bb
@@ -9,7 +9,7 @@ SRC_URI = "file://shm-util.c \
 S = "${WORKDIR}"
 
 do_compile() {
-    ${CC} shm-util.c -o shm-util
+    ${CC} shm-util.c ${LDFLAGS} -o shm-util
 }
 
 do_install() {


### PR DESCRIPTION
After a change in openembedded-core, we're now getting more accurate information
about components that do not properly use the build system LDFLAGS in linking.

See http://git.yoctoproject.org/cgit.cgi/poky/commit/?id=a98a8180863ff45b477a1f8439ebcec21151d282

The test utils in recipes-test do not seem to use ${LDFLAGS} and
we're hit by a package QA test error.

Add ${LDFLAGS} to get rid of the failure.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>