### PR TITLE
[rest-apis] Update the REST API test cases.

### DIFF
--- a/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_d.js
+++ b/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_d.js
@@ -81,60 +81,77 @@ module.exports = {
     // required properties
     // n
     testApiOicDRequiredNNotNull: function(test) {
-        test.ok('n' in this.apiOicD.apiResponse[0],
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            test.ok('n' in this.apiOicD.apiResponse[i],
                     'n is not a property in the response of /api/oic/d while it is required!');
-        test.done();
+        }
+        test.done();        
     },
     testApiOicDRequiredNType: function(test) {
-        test.strictEqual(typeof this.apiOicD.apiResponse[0]['n'], 'string',
-                        'n property is not a string!');
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            test.strictEqual(typeof this.apiOicD.apiResponse[i]['n'], 'string',
+                            'n property is not a string!');            
+        }
         test.done();
     },
 
     // di
     testApiOicDRequiredDiNotNull: function(test) {
-        test.ok('di' in this.apiOicD.apiResponse[0],
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            test.ok('di' in this.apiOicD.apiResponse[i],
                     'di is not a property in the response of /api/oic/d while it is required!');
+        }
         test.done();
     },
     testApiOicDRequiredDiType: function(test) {
-        test.strictEqual(typeof this.apiOicD.apiResponse[0]['di'], 'string',
-                        'di property is not a string!');
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            test.strictEqual(typeof this.apiOicD.apiResponse[i]['di'], 'string',
+                            'di property is not a string!');
+        }
         test.done();
     },
     testApiOicDRequiredDiUuid: function(test) {
-        test.ok(checkStrIsUuid(this.apiOicD.apiResponse[0]['di']),
-                    'n property value is not UUID format!');
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            test.ok(checkStrIsUuid(this.apiOicD.apiResponse[i]['di']),
+                        'n property value is not UUID format!');
+        }
         test.done();
     },
 
     // icv
     testApiOicDRequiredIcvNotNull: function(test) {
-        test.ok('icv' in this.apiOicD.apiResponse[0],
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            test.ok('icv' in this.apiOicD.apiResponse[i],
                     'icv is not a property in the response of /api/oic/d while it is required!');
+        }
         test.done();
     },
     testApiOicRequiredDIcvType: function(test) {
-        test.strictEqual(typeof this.apiOicD.apiResponse[0]['icv'], 'string',
-                        'icv property is not a string!');
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            test.strictEqual(typeof this.apiOicD.apiResponse[i]['icv'], 'string',
+                            'icv property is not a string!');
+        }
         test.done();
     },
 
     // optional properties
     // dmv
     testApiOicDOptionalDmvType: function(test) {
-        if ('dmv' in this.apiOicD.apiResponse[0]) {
-            test.strictEqual(typeof this.apiOicD.apiResponse[0]['dmv'], 'string',
-                        'dmv property is not a string!');
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            if ('dmv' in this.apiOicD.apiResponse[i]) {
+                test.strictEqual(typeof this.apiOicD.apiResponse[i]['dmv'], 'string',
+                                'dmv property is not a string!');
+            }
         }
         test.done();
     },
     testApiOicDOptionalDmvCsv: function(test) {
-        if ('dmv' in this.apiOicD.apiResponse[0]) {
-            test.ok(checkStrIsCsv(this.apiOicD.apiResponse[0]['dmv']),
-                        'dmv property value is not csv format!');
+        for (var i = 0; i < this.apiOicD.apiResponse.length; i++) {
+            if ('dmv' in this.apiOicD.apiResponse[i]) {
+                test.ok(checkStrIsCsv(this.apiOicD.apiResponse[i]['dmv']),
+                            'dmv property value is not csv format!');
+            }
         }
         test.done();
     }
-
 };

--- a/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_p.js
+++ b/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_p.js
@@ -55,99 +55,125 @@ module.exports = {
     // required properties
     // pi
     testApiOicPRequiredPiNotNull: function(test) {
-        test.ok('pi' in this.apiOicP.apiResponse, 
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            test.ok('pi' in this.apiOicP.apiResponse[i],
                     'pi is not a property in the response of /api/oic/p while it is required!');
+        }
         test.done();
     },
     testApiOicPRequiredPiType: function(test) {
-        test.strictEqual(typeof this.apiOicP.apiResponse['pi'], 'string',                         
-                        'pi property is not a string!');
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            test.strictEqual(typeof this.apiOicP.apiResponse[i]['pi'], 'string',                         
+                            'pi property is not a string!');
+        }
         test.done();
     },
     
     // mnmn
     testApiOicPRequiredMnmnNotNull: function(test) {
-        test.ok('mnmn' in this.apiOicP.apiResponse, 
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            test.ok('mnmn' in this.apiOicP.apiResponse[i], 
                     'mnmn is not a property in the response of /api/oic/p while it is required!');
+        }
         test.done();
     },
     testApiOicPRequiredMnmnType: function(test) {
-        test.strictEqual(typeof this.apiOicP.apiResponse['mnmn'], 'string',                         
-                        'mnmn property is not a string!');
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            test.strictEqual(typeof this.apiOicP.apiResponse[i]['mnmn'], 'string',                         
+                            'mnmn property is not a string!');
+        }
         test.done();
     },
     
     // optional properties
     // mnml
     testApiOicPOptionalMnmlType: function(test) {
-        if ('mnml' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['mnml'], 'string',
-                            'mnml property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('mnml' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse[i]['mnml'], 'string',
+                                'mnml property is not a string!');
+            }            
         }
         test.done();
     },
     // mnmo
     testApiOicPOptionalMnmoType: function(test) {
-        if ('mnmo' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['mnmo'], 'string',
-                            'mnmo property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('mnmo' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse[i]['mnmo'], 'string',
+                                'mnmo property is not a string!');
+            }            
         }
         test.done();
     },    
     // mndt
     testApiOicPOptionalMndtType: function(test) {
-        if ('mndt' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['mndt'], 'string',
-                            'mndt property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('mndt' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse[i]['mndt'], 'string',
+                                'mndt property is not a string!');
+            }       
         }
         test.done();
     },    
     // mnpv
     testApiOicPOptionalMnpvType: function(test) {
-        if ('mnpv' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['mnpv'], 'string',
-                            'mnpv property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('mnpv' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse[i]['mnpv'], 'string',
+                                'mnpv property is not a string!');
+            }       
         }
         test.done();
     },
     // mnos
     testApiOicPOptionalMnosType: function(test) {
-        if ('mnos' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['mnos'], 'string',
-                            'mnos property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('mnos' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse[i]['mnos'], 'string',
+                                'mnos property is not a string!');
+            }
         }
         test.done();
-    },    
+    },
     // mnhw
     testApiOicPOptionalMnhwType: function(test) {
-        if ('mnhw' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['mnhw'], 'string',
-                            'mnhw property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('mnhw' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse[i]['mnhw'], 'string',
+                                'mnhw property is not a string!');
+            }
         }
         test.done();
     },  
     // mnfv
     testApiOicPOptionalMnfvType: function(test) {
-        if ('mnfv' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['mnfv'], 'string',
-                            'mnfv property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('mnfv' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse[i]['mnfv'], 'string',
+                                'mnfv property is not a string!');
+            }
         }
         test.done();
     },       
     // mnsl
     testApiOicPOptionalMnslType: function(test) {
-        if ('mnsl' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['mnsl'], 'string',
-                            'mnsl property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('mnsl' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse['mnsl'], 'string',
+                                'mnsl property is not a string!');       
+            }
         }
         test.done();
     },      
     // st
     testApiOicPOptionalStType: function(test) {
-        if ('st' in this.apiOicP.apiResponse) {
-            test.strictEqual(typeof this.apiOicP.apiResponse['st'], 'string',
-                            'st property is not a string!');            
+        for (var i = 0; i < this.apiOicP.apiResponse.length; i++) {
+            if ('st' in this.apiOicP.apiResponse) {
+                test.strictEqual(typeof this.apiOicP.apiResponse['st'], 'string',
+                                'st property is not a string!');
+            }
         }
         test.done();
     },          
-}
+};

--- a/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_res.js
+++ b/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_oic_res.js
@@ -98,4 +98,4 @@ module.exports = {
         }
         test.done();
     }, 
-}
+};

--- a/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_system.js
+++ b/lib/oeqa/runtime/nodejs/files/restapis/nodeunit_test_api_system.js
@@ -9,15 +9,15 @@ var options = {
     path: '/api/system',
     method: 'GET',
     headers: {
-        'Accept': 'text/json'    
-    }    
+        'Accept': 'text/json'
+    }
 };
 
 var apiSystem = {};
 var responseJson = path.join(path.dirname(__filename), 'api_system.json');
 
 function sendHttpRequest(opts) {
-    var req = http.request(opts, function(res) {    
+    var req = http.request(opts, function (res) {
         apiSystem.statusCode = res.statusCode;
         res.setEncoding('utf8');
         
@@ -84,11 +84,11 @@ module.exports = {
     testApiSystemTypeValue: function(test) {
         test.strictEqual(this.apiSystem.apiResponse['type'], os.type(),                        
                         'local type value differs from the one from api response!');
-        test.done();                        
-    },  
-    
+        test.done();
+    },
+
     // arch    
-    testApiSystemArchNotNull: function(test) {
+    testApiSystemArchNotNull: function (test) {
         test.ok('arch' in this.apiSystem.apiResponse,
                     'arch is not a property in the response of /api/system!');
         test.done();
@@ -208,6 +208,6 @@ module.exports = {
         var localNetworkInterfaces = os.networkInterfaces();
         test.deepEqual(this.apiSystem.apiResponse['networkinterfaces'], localNetworkInterfaces,
                                 'local network interfaces differs from the one from /api/system!');
-        test.done();                                
+        test.done();
     } 
 };

--- a/lib/oeqa/runtime/nodejs/rest_apis.py
+++ b/lib/oeqa/runtime/nodejs/rest_apis.py
@@ -40,7 +40,7 @@ class RESTAPITest(oeRuntimeTest):
 
         'api_system': 'nodeunit_test_api_system.js',
         'api_oic_d': 'nodeunit_test_api_oic_d.js',
-        #'api_oic_p': 'nodeunit_test_api_oic_p.js',
+        'api_oic_p': 'nodeunit_test_api_oic_p.js',
         'api_oic_res': 'nodeunit_test_api_oic_res.js'
 
     }
@@ -154,7 +154,7 @@ class RESTAPITest(oeRuntimeTest):
         if os.path.exists(cls.nodeunit_zip):
             #change nodeunit zip to tar
             os.chdir(cls.files_dir)
-            os.system('unzip -oq %s; tar -cf master.tar nodeunit-master; rm -rf nodeunit-master' %\
+            os.system('unzip -oq %s; cd nodeunit-master;npm install;cd ..;tar -cf master.tar nodeunit-master; rm -rf nodeunit-master' %\
                 (cls.nodeunit_zip)
             )
             cls.nodeunit_tar = os.path.join(cls.files_dir, 'master.tar')
@@ -164,6 +164,7 @@ class RESTAPITest(oeRuntimeTest):
                             'chmod +x /tmp/nodeunit-master/bin/nodeunit'
                            )
 
+        cls.tc.target.run("/usr/sbin/iptables -w -A INPUT -p udp --dport 5683 -j ACCEPT")
         cls.tc.target.run('/opt/iotivity/examples/resource/c/SimpleClientServer/ocserver -o 0')
         for api, api_js in cls.rest_api_js_files.items():
             cls.tc.target.run('cd %s; node %s' % (cls.target_rest_api_dir, api_js) )
@@ -1035,340 +1036,340 @@ class RESTAPITest(oeRuntimeTest):
         self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_status_code(self):
-    #     '''
-    #     Test status code of /api/oic/p.
-    #     @fn test_api_oic_p_status_code
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPStatusCode' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_status_code
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_status_code
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_status_code(self):
+        '''
+        Test status code of /api/oic/p.
+        @fn test_api_oic_p_status_code
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPStatusCode' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_status_code
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_status_code
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_has_required_pi(self):
-    #     '''
-    #     Test if the response of /api/oic/pi has required property pi.
-    #     @fn test_api_oic_p_has_required_pi
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredPiNotNull' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_has_required_pi
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_has_required_pi
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_has_required_pi(self):
+        '''
+        Test if the response of /api/oic/pi has required property pi.
+        @fn test_api_oic_p_has_required_pi
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredPiNotNull' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_has_required_pi
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_has_required_pi
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_required_pi_type(self):
-    #     '''
-    #     Test if the type of pi property in response is string.
-    #     @fn test_api_oic_p_required_pi_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredPiType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_required_pi_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_required_pi_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_required_pi_type(self):
+        '''
+        Test if the type of pi property in response is string.
+        @fn test_api_oic_p_required_pi_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredPiType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_required_pi_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_required_pi_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_has_required_mnmn(self):
-    #     '''
-    #     Test if the response of /api/oic/p has required property mnmn.
-    #     @fn test_api_oic_p_has_required_mnmn
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredMnmnNotNull' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_has_required_mnmn
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_has_required_mnmn
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_has_required_mnmn(self):
+        '''
+        Test if the response of /api/oic/p has required property mnmn.
+        @fn test_api_oic_p_has_required_mnmn
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredMnmnNotNull' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_has_required_mnmn
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_has_required_mnmn
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_required_mnmn_type(self):
-    #     '''
-    #     Test if the type of mnmn property in response is string.
-    #     @fn test_api_oic_p_required_mnmn_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredMnmnType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_required_mnmn_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_required_mnmn_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_required_mnmn_type(self):
+        '''
+        Test if the type of mnmn property in response is string.
+        @fn test_api_oic_p_required_mnmn_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPRequiredMnmnType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_required_mnmn_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_required_mnmn_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_mnml_type(self):
-    #     '''
-    #     Test if the type of mnml property in response is string.
-    #     @fn test_api_oic_p_optional_mnml_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnmlType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_mnml_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_mnml_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_mnml_type(self):
+        '''
+        Test if the type of mnml property in response is string.
+        @fn test_api_oic_p_optional_mnml_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnmlType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_mnml_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_mnml_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_mnmo_type(self):
-    #     '''
-    #     Test if the type of mnmo property in response is string.
-    #     @fn test_api_oic_p_optional_mnmo_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnmoType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_mnmo_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_mnmo_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_mnmo_type(self):
+        '''
+        Test if the type of mnmo property in response is string.
+        @fn test_api_oic_p_optional_mnmo_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnmoType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_mnmo_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_mnmo_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_mndt_type(self):
-    #     '''
-    #     Test if the type of mndt property in response is string.
-    #     @fn test_api_oic_p_optional_mndt_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMndtType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_mndt_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_mndt_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_mndt_type(self):
+        '''
+        Test if the type of mndt property in response is string.
+        @fn test_api_oic_p_optional_mndt_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMndtType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_mndt_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_mndt_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_mnpv_type(self):
-    #     '''
-    #     Test if the type of mnpv property in response is string.
-    #     @fn test_api_oic_p_optional_mnpv_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnpvType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_mnpv_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_mnpv_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_mnpv_type(self):
+        '''
+        Test if the type of mnpv property in response is string.
+        @fn test_api_oic_p_optional_mnpv_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnpvType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_mnpv_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_mnpv_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_mnos_type(self):
-    #     '''
-    #     Test if the type of mnos property in response is string.
-    #     @fn test_api_oic_p_optional_mnos_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnosType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_mnos_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_mnos_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_mnos_type(self):
+        '''
+        Test if the type of mnos property in response is string.
+        @fn test_api_oic_p_optional_mnos_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnosType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_mnos_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_mnos_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_mnhw_type(self):
-    #     '''
-    #     Test if the type of mnhw property in response is string.
-    #     @fn test_api_oic_p_optional_mnhw_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnhwType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_mnhw_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_mnhw_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_mnhw_type(self):
+        '''
+        Test if the type of mnhw property in response is string.
+        @fn test_api_oic_p_optional_mnhw_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnhwType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_mnhw_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_mnhw_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_mnfv_type(self):
-    #     '''
-    #     Test if the type of mnfv property in response is string.
-    #     @fn test_api_oic_p_optional_mnfv_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnfvType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_mnfv_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_mnfv_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_mnfv_type(self):
+        '''
+        Test if the type of mnfv property in response is string.
+        @fn test_api_oic_p_optional_mnfv_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnfvType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_mnfv_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_mnfv_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_mnsl_type(self):
-    #     '''
-    #     Test if the type of mnfv property in response is string.
-    #     @fn test_api_oic_p_optional_mnsl_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnslType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_mnsl_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_mnsl_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_mnsl_type(self):
+        '''
+        Test if the type of mnfv property in response is string.
+        @fn test_api_oic_p_optional_mnsl_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalMnslType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_mnsl_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_mnsl_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
-    # def test_api_oic_p_optional_st_type(self):
-    #     '''
-    #     Test if the type of st property in response is string.
-    #     @fn test_api_oic_p_optional_st_type
-    #     @param self
-    #     @return
-    #     '''
-    #     (api_status, api_output) = self.target.run(
-    #             'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalStType' % (
-    #                 self.target_rest_api_dir,
-    #                 self.target_rest_api_dir,
-    #                 self.rest_api_js_files['api_oic_p']
-    #                )
-    #     )
-    #     ##
-    #     # TESTPOINT: #1, test_api_oic_p_optional_st_type
-    #     #
-    #     self.assertEqual(api_status, 0)
-    #     ##
-    #     # TESTPOINT: #2, test_api_oic_p_optional_st_type
-    #     #
-    #     self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
+    def test_api_oic_p_optional_st_type(self):
+        '''
+        Test if the type of st property in response is string.
+        @fn test_api_oic_p_optional_st_type
+        @param self
+        @return
+        '''
+        (api_status, api_output) = self.target.run(
+                'cd %s/; /tmp/nodeunit-master/bin/nodeunit %s/%s -t testApiOicPOptionalStType' % (
+                    self.target_rest_api_dir,
+                    self.target_rest_api_dir,
+                    self.rest_api_js_files['api_oic_p']
+                   )
+        )
+        ##
+        # TESTPOINT: #1, test_api_oic_p_optional_st_type
+        #
+        self.assertEqual(api_status, 0)
+        ##
+        # TESTPOINT: #2, test_api_oic_p_optional_st_type
+        #
+        self.assertTrue('OK:' in api_output.strip().splitlines()[-1])
 
 
     def test_api_oic_res_status_code(self):
@@ -1515,6 +1516,8 @@ class RESTAPITest(oeRuntimeTest):
         cls.tc.target.run('rm -fr /tmp/nodeunit-master')
         cls.tc.target.run('rm -f /tmp/master.tar')
         cls.tc.target.run('rm -rf /tmp/modules')
+
+        cls.tc.target.run("/usr/sbin/iptables -w -D INPUT -p udp --dport 5683 -j ACCEPT")
 
 ##
 # @}


### PR DESCRIPTION
- Fix the nodeunit dependencies issue.
- Open 5683 port before running test cases to avoid the REST APIs
return an empty array value when discoverying devices or resources.
- Enable the test cases for /api/oic/p

Signed-off-by: Zhong Qiu zhongx.qiu@intel.com