### PR TITLE
Update test case id for bleno and crypto api

### DIFF
--- a/lib/oeqa/runtime/nodejs/bleno.py
+++ b/lib/oeqa/runtime/nodejs/bleno.py
@@ -80,13 +80,13 @@ class BlenoTest(oeRuntimeTest):
                 fp.write('{t} - runtest.py - RESULTS - ' \
                         'Testcase {tc_name}: {result}\n'.format(
                         t = time.strftime('%H:%M:%S', time.localtime()),
-                        tc_name = '"{tc}"'.format(tc = passed_tc.get('fullTitle')),
+                        tc_name = '{tc}'.format(tc = passed_tc.get('fullTitle').replace(' ', '_')),
                         result = 'PASSED'))
             for failed_tc in result_json.get('failures'):
                 fp.write('{t} - runtest.py - RESULTS - ' \
                         'Testcase {tc_name}: {result}\n'.format(
                         t = time.strftime('%H:%M:%S', time.localtime()),
-                        tc_name = '"{tc}"'.format(tc = failed_tc.get('fullTitle')),
+                        tc_name = '{tc}'.format(tc = failed_tc.get('fullTitle').replace(' ', '_')),
                         result = 'FAILED'))
             
 

--- a/lib/oeqa/runtime/nodejs/crypto_api.py
+++ b/lib/oeqa/runtime/nodejs/crypto_api.py
@@ -170,7 +170,7 @@ class NodeJSCryptoAPITest(oeRuntimeTest):
                 fp.write('{t} - runtest.py - RESULTS - ' \
                         'Testcase {tc_name}: {result}\n'.format(
                         t = time.strftime('%H:%M:%S', time.localtime()),
-                        tc_name = tc.replace('/', '.').rstrip('.js'),
+                        tc_name = os.path.splitext(tc)[0].replace('/', '.'),
                         result = tc_result))
             
  


### PR DESCRIPTION
- Replace white spaces with underscores for the bleno test case id.
- Fix inproper way of chopping .js extension issue for the crypto test case id.